### PR TITLE
Authorization support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   COVERALLS_REPO_TOKEN: 
     secure:ZOotByGmB2CHvWqjjKkuBJd9g2akvEajO87x4kW1cTVjUYHPQv9KmHa9+YRCnIHU
+  CODECOV_TOKEN:
+    secure: ycGY4b36w5tfqg4/uuKUTltDs6kN19q4VqAguuRBW4B/bGbdlalu4kwj9FYVwjB2
 pull_requests:
   do_not_increment_build_number: true
 init:
@@ -17,24 +19,16 @@ before_build:
 build_script:
 - dotnet build "src\RService.IO" -c %CONFIGURATION% --version-suffix %LABEL%
 - dotnet build "src\RService.IO.Abstractions" -c %CONFIGURATION% --version-suffix %LABEL%
-after_build:
+test_script:
+  - ps: '& ${env:homedrive}${env:homepath}\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe "-target:C:\Program Files\dotnet\dotnet.exe" -targetargs:"test .\test\RService.IO.Tests" -register:user -filter:"+[RService.IO*]* -[RService.IO.Tests*]*" -output:coverage.xml -oldStyle'
+  - ps: '& ${env:homedrive}${env:homepath}\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe "-target:C:\Program Files\dotnet\dotnet.exe" -targetargs:"test .\test\RService.IO.Tests.Integration" -register:user -filter:"+[RService.IO*]* -[RService.IO.Tests*]*" -mergeoutput -output:coverage.xml -oldStyle'
+  - ps: '& ${env:homedrive}${env:homepath}\.nuget\packages\coveralls.io\1.3.4\tools\coveralls.net.exe --opencover coverage.xml'
+  - ps: pip install codecov;  codecov -f coverage.xml -X gcov
+after_test:
 #- dotnet pack "src\LibNETStandard10" -c %CONFIGURATION% --no-build --version-suffix %LABEL% -o artifacts
 #- dotnet publish "src\ConsoleApplication" -c %CONFIGURATION% --no-build --version-suffix %LABEL% -o artifacts\ConsoleApplication
-  - ps: >-
-      $ProgramFiles86 = (${env:ProgramFiles(x86)}, ${env:ProgramFiles} -ne $null)[0]
-
-      & ${env:homedrive}${env:homepath}\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe "-target:C:\Program Files\dotnet\dotnet.exe" -targetargs:"test .\test\RService.IO.Tests" -register:user -filter:"+[RService.IO*]* -[RService.IO.Tests*]*" -output:coverage.xml -oldStyle
-
-      & ${env:homedrive}${env:homepath}\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe "-target:C:\Program Files\dotnet\dotnet.exe" -targetargs:"test .\test\RService.IO.Tests.Integration" -register:user -filter:"+[RService.IO*]* -[RService.IO.Tests*]*" -mergeoutput -output:coverage.xml -oldStyle
-
-      & ${env:homedrive}${env:homepath}\.nuget\packages\coveralls.io\1.3.4\tools\coveralls.net.exe --opencover coverage.xml
-
-      dotnet pack "src\RService.IO" -c ${env:CONFIGUREATION} --no-build --version-suffix ${env:LABEL} -o artifacts
-
-      & dotnet pack "src\RService.IO.Abstractions" -c ${env:CONFIGUREATION} --no-build --version-suffix ${env:LABEL} -o artifacts
-test_script:
-- dotnet test "test\RService.IO.Tests" -c %CONFIGURATION%
-- dotnet test "test\RService.IO.Tests.Integration" -c %CONFIGURATION%
+  - ps: dotnet pack "src\RService.IO" -c ${env:CONFIGUREATION} --no-build --version-suffix ${env:LABEL} -o artifacts
+  - ps: dotnet pack "src\RService.IO.Abstractions" -c ${env:CONFIGUREATION} --no-build --version-suffix ${env:LABEL} -o artifacts
 artifacts:
   - path: '**/RService.IO.*.nupkg'
     name: NuGet Package

--- a/src/RService.IO.Abstractions/ApiException.cs
+++ b/src/RService.IO.Abstractions/ApiException.cs
@@ -3,42 +3,42 @@ using System.Net;
 
 namespace RService.IO.Abstractions
 {
-    public class ApiExceptions : Exception
+    public class ApiException : Exception
     {
         public HttpStatusCode StatusCode { get; protected set; } = HttpStatusCode.InternalServerError;
 
-        public ApiExceptions()
+        public ApiException()
         {
         }
 
-        public ApiExceptions(string message)
+        public ApiException(string message)
             : base(message)
         {
         }
 
-        public ApiExceptions(HttpStatusCode statusCode)
+        public ApiException(HttpStatusCode statusCode)
         {
             StatusCode = statusCode;
         }
 
-        public ApiExceptions(string message, HttpStatusCode statusCode)
+        public ApiException(string message, HttpStatusCode statusCode)
             : base(message)
         {
             StatusCode = statusCode;
         }
 
-        public ApiExceptions(string message, Exception inner)
+        public ApiException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
-        public ApiExceptions(HttpStatusCode statusCode, Exception inner)
+        public ApiException(HttpStatusCode statusCode, Exception inner)
             : base(string.Empty, inner)
         {
             StatusCode = statusCode;
         }
 
-        public ApiExceptions(string message, HttpStatusCode statusCode, Exception inner)
+        public ApiException(string message, HttpStatusCode statusCode, Exception inner)
             : base(message, inner)
         {
             StatusCode = statusCode;

--- a/src/RService.IO.Abstractions/IAuthProvider.cs
+++ b/src/RService.IO.Abstractions/IAuthProvider.cs
@@ -17,13 +17,6 @@ namespace RService.IO.Abstractions
     public interface IAuthProvider
     {
         /// <summary>
-        /// Checks AuthN of the request.
-        /// </summary>
-        /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
-        /// <returns><b>True</b> if the request is authenticated, else <b>False</b>.</returns>
-        bool IsAuthenticated(HttpContext ctx);
-
-        /// <summary>
         /// Checks AuthZ on a given endpoint.
         /// </summary>
         /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
@@ -33,15 +26,5 @@ namespace RService.IO.Abstractions
         /// All attributes on an endpoint and class must evaluate to <b>True</b> for this to return <b>True</b>.
         /// </remarks>
         Task<bool> IsAuthorizedAsync(HttpContext ctx, IEnumerable<object> authorizationFilters);
-
-        /// <summary>
-        /// If AuthZ failed this will challenge the user for new AuthZ.
-        /// </summary>
-        /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
-        /// <param name="authorizationFilters">A collection of "authorized"/"allow anonymous" attributes.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that on completion indicates the filter has executed.
-        /// </returns>
-        Task OnChallengeAuthorizationAsync(HttpContext ctx, IEnumerable<object> authorizationFilters);
     }
 }

--- a/src/RService.IO.Abstractions/IAuthProvider.cs
+++ b/src/RService.IO.Abstractions/IAuthProvider.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace RService.IO.Abstractions
+{
+    /// <summary>
+    /// Determines if a service endpoint is authenticated and authorized to be executed.
+    /// </summary>
+    /// <remarks>
+    /// These methods should be used prior to executing the service. <br/><br/>
+    /// Also if there are more than one Authorization attribute on a class and/or
+    /// method then all authorizations must pass.  If there is only one
+    /// Authorization attribute with a comma separated list then only one attribute
+    /// must be satisfied.
+    /// </remarks>
+    public interface IAuthProvider
+    {
+        /// <summary>
+        /// Checks if the request is authenticated.
+        /// </summary>
+        /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
+        /// <returns><b>True</b> if the request is authenticated, else <b>False</b>.</returns>
+        bool IsAuthenticated(HttpContext ctx);
+
+        /// <summary>
+        /// Checks if the requester is authorized to given endpoint.
+        /// </summary>
+        /// <param name="user">The <see cref="ClaimsPrincipal"/> of the user.</param>
+        /// <param name="authorizationFilters">A collection of "authorized"/"allow anonymous" attributes.</param>
+        /// <returns><b>True</b> if the user is authorized for the given endpoint, else <b>False</b>.</returns>
+        /// <remarks>
+        /// All attributes on an endpoint and class must evaluate to <b>True</b> for this to return <b>True</b>.
+        /// </remarks>
+        bool IsAuthorized(ClaimsPrincipal user, IEnumerable<object> authorizationFilters);
+    }
+}

--- a/src/RService.IO.Abstractions/IAuthProvider.cs
+++ b/src/RService.IO.Abstractions/IAuthProvider.cs
@@ -17,11 +17,26 @@ namespace RService.IO.Abstractions
     public interface IAuthProvider
     {
         /// <summary>
-        /// Checks AuthZ on a given endpoint.
+        /// Checks authorization on a given endpoint.
+        /// </summary>
+        /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
+        /// <param name="metadata">The endpoint <see cref="ServiceMetadata"/>.</param>
+        /// <returns>
+        /// <b>True</b> if the user is authorized for the given endpoint, else <b>False</b>.
+        /// </returns>
+        /// <remarks>
+        /// All attributes on an endpoint and class must evaluate to <b>True</b> for this to return <b>True</b>.
+        /// </remarks>
+        Task<bool> IsAuthorizedAsync(HttpContext ctx, ServiceMetadata metadata);
+
+        /// <summary>
+        /// Checks authorization on a given endpoint.
         /// </summary>
         /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
         /// <param name="authorizationFilters">A collection of "authorized"/"allow anonymous" attributes.</param>
-        /// <returns><b>True</b> if the user is authorized for the given endpoint, else <b>False</b>.</returns>
+        /// <returns>
+        /// <b>True</b> if the user is authorized for the given endpoint, else <b>False</b>.
+        /// </returns>
         /// <remarks>
         /// All attributes on an endpoint and class must evaluate to <b>True</b> for this to return <b>True</b>.
         /// </remarks>

--- a/src/RService.IO.Abstractions/IAuthProvider.cs
+++ b/src/RService.IO.Abstractions/IAuthProvider.cs
@@ -17,14 +17,14 @@ namespace RService.IO.Abstractions
     public interface IAuthProvider
     {
         /// <summary>
-        /// Checks if the request is authenticated.
+        /// Checks AuthN of the request.
         /// </summary>
         /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
         /// <returns><b>True</b> if the request is authenticated, else <b>False</b>.</returns>
         bool IsAuthenticated(HttpContext ctx);
 
         /// <summary>
-        /// Checks if the requester is authorized to given endpoint.
+        /// Checks AuthZ on a given endpoint.
         /// </summary>
         /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
         /// <param name="authorizationFilters">A collection of "authorized"/"allow anonymous" attributes.</param>
@@ -35,13 +35,13 @@ namespace RService.IO.Abstractions
         Task<bool> IsAuthorizedAsync(HttpContext ctx, IEnumerable<object> authorizationFilters);
 
         /// <summary>
-        /// Called early in the filter pipeline to confirm request is authorized.
+        /// If AuthZ failed this will challenge the user for new AuthZ.
         /// </summary>
         /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
         /// <param name="authorizationFilters">A collection of "authorized"/"allow anonymous" attributes.</param>
         /// <returns>
         /// A <see cref="Task"/> that on completion indicates the filter has executed.
         /// </returns>
-        Task OnAuthorizationAsync(HttpContext ctx, IEnumerable<object> authorizationFilters);
+        Task OnChallengeAuthorizationAsync(HttpContext ctx, IEnumerable<object> authorizationFilters);
     }
 }

--- a/src/RService.IO.Abstractions/IAuthProvider.cs
+++ b/src/RService.IO.Abstractions/IAuthProvider.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace RService.IO.Abstractions
@@ -26,12 +26,22 @@ namespace RService.IO.Abstractions
         /// <summary>
         /// Checks if the requester is authorized to given endpoint.
         /// </summary>
-        /// <param name="user">The <see cref="ClaimsPrincipal"/> of the user.</param>
+        /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
         /// <param name="authorizationFilters">A collection of "authorized"/"allow anonymous" attributes.</param>
         /// <returns><b>True</b> if the user is authorized for the given endpoint, else <b>False</b>.</returns>
         /// <remarks>
         /// All attributes on an endpoint and class must evaluate to <b>True</b> for this to return <b>True</b>.
         /// </remarks>
-        bool IsAuthorized(ClaimsPrincipal user, IEnumerable<object> authorizationFilters);
+        Task<bool> IsAuthorizedAsync(HttpContext ctx, IEnumerable<object> authorizationFilters);
+
+        /// <summary>
+        /// Called early in the filter pipeline to confirm request is authorized.
+        /// </summary>
+        /// <param name="ctx">The <see cref="HttpContext"/> of the request.</param>
+        /// <param name="authorizationFilters">A collection of "authorized"/"allow anonymous" attributes.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that on completion indicates the filter has executed.
+        /// </returns>
+        Task OnAuthorizationAsync(HttpContext ctx, IEnumerable<object> authorizationFilters);
     }
 }

--- a/src/RService.IO.Abstractions/IRServiceFeature.cs
+++ b/src/RService.IO.Abstractions/IRServiceFeature.cs
@@ -4,6 +4,7 @@ namespace RService.IO.Abstractions
 {
     public interface IRServiceFeature
     {
+        ServiceMetadata Metadata { get; set; }
         Delegate.Activator MethodActivator { get; set; }
         IService Service { get; set; }
         Type RequestDtoType { get; set; }

--- a/src/RService.IO.Abstractions/RServiceHttpContextExtensions.cs
+++ b/src/RService.IO.Abstractions/RServiceHttpContextExtensions.cs
@@ -38,7 +38,7 @@ namespace RService.IO.Abstractions
             return feature?.Service;
         }
 
-        public static ServiceMetadata GetMetadata(this HttpContext context)
+        public static ServiceMetadata GetServiceMetadata(this HttpContext context)
         {
 
             if (context == null)

--- a/src/RService.IO.Abstractions/RServiceHttpContextExtensions.cs
+++ b/src/RService.IO.Abstractions/RServiceHttpContextExtensions.cs
@@ -37,5 +37,14 @@ namespace RService.IO.Abstractions
             var feature = context.Features[typeof(IRServiceFeature)] as IRServiceFeature;
             return feature?.Service;
         }
+
+        public static ServiceMetadata GetMetadata(this HttpContext context)
+        {
+
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            var feature = context.Features[typeof(IRServiceFeature)] as IRServiceFeature;
+            return feature?.Metadata;
+        }
     }
 }

--- a/src/RService.IO.Abstractions/ServiceMetadata.cs
+++ b/src/RService.IO.Abstractions/ServiceMetadata.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+
+namespace RService.IO.Abstractions
+{
+    /// <summary>
+    /// Metadata about a RService.IO web service.
+    /// </summary>
+    public class ServiceMetadata
+    {
+        /// <summary>
+        /// The unique identifier.
+        /// </summary>
+        public string Ident { get; set; }
+        /// <summary>
+        /// Metadata on the service.
+        /// </summary>
+        public TypeInfo Service { get; set; }
+        /// <summary>
+        /// Metadata on the method.
+        /// </summary>
+        public MethodInfo Method { get; set; }
+    }
+}

--- a/src/RService.IO.Abstractions/project.json
+++ b/src/RService.IO.Abstractions/project.json
@@ -10,6 +10,8 @@
       "microservice",
       "webservice",
       "dotnet core",
+      "api",
+      "RESTful",
       "RService.IO"
     ],
     "licenseUrl": "https://github.com/Stoom/RService.IO/blob/master/LICENSE",

--- a/src/RService.IO/DependencyIngection/ServiceCollectionExtensions.cs
+++ b/src/RService.IO/DependencyIngection/ServiceCollectionExtensions.cs
@@ -49,5 +49,15 @@ namespace RService.IO.DependencyIngection
 
             return services;
         }
+
+        public static IServiceCollection AddRServiceIoAuthorization(
+            this IServiceCollection services)
+        {
+            services.AddOptions();
+
+            services.TryAddTransient<IAuthProvider, AuthProvider>();
+
+            return services;
+        }
     }
 }

--- a/src/RService.IO/Providers/AuthProvider.cs
+++ b/src/RService.IO/Providers/AuthProvider.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using RService.IO.Abstractions;
+
+namespace RService.IO.Providers
+{
+    /// <summary>
+    /// Default implementation of <see cref="IAuthProvider"/>.
+    /// </summary>
+    public class AuthProvider : IAuthProvider
+    {
+        /// <inheritdoc/>
+        public bool IsAuthenticated(HttpContext ctx)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public bool IsAuthorized(ClaimsPrincipal user, IEnumerable<object> authorizationFilters)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/RService.IO/Providers/AuthProvider.cs
+++ b/src/RService.IO/Providers/AuthProvider.cs
@@ -1,6 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Internal;
 using RService.IO.Abstractions;
 
 namespace RService.IO.Providers
@@ -10,16 +17,104 @@ namespace RService.IO.Providers
     /// </summary>
     public class AuthProvider : IAuthProvider
     {
-        /// <inheritdoc/>
-        public bool IsAuthenticated(HttpContext ctx)
+        private readonly IAuthorizationPolicyProvider _policyProvider;
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="provider"></param>
+        public AuthProvider(IAuthorizationPolicyProvider provider)
         {
-            throw new System.NotImplementedException();
+            if (provider == null)
+                throw new ArgumentNullException(nameof(provider));
+
+            _policyProvider = provider;
         }
 
         /// <inheritdoc/>
-        public bool IsAuthorized(ClaimsPrincipal user, IEnumerable<object> authorizationFilters)
+        public bool IsAuthenticated(HttpContext ctx)
         {
-            throw new System.NotImplementedException();
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> IsAuthorizedAsync(HttpContext ctx, IEnumerable<object> authorizationFilters)
+        {
+            var results = await AuthorizedAsync(ctx, authorizationFilters);
+            return results.IsAuthorized;
+        }
+
+        /// <inheritdoc/>
+        public async Task OnAuthorizationAsync(HttpContext ctx, IEnumerable<object> authorizationFilters)
+        {
+            var response = await AuthorizedAsync(ctx, authorizationFilters);
+            if (!response.IsAuthorized)
+            {
+                if (response.AuthenticationSchemes?.Any() ?? false)
+                {
+                    foreach (var scheme in response.AuthenticationSchemes)
+                    {
+                        await ctx.Authentication.ChallengeAsync(scheme);
+                    }
+                }
+                else
+                {
+                    await ctx.Authentication.ChallengeAsync((AuthenticationProperties) null);
+                }
+            }
+        }
+
+        private async Task<ChallangeResponse> AuthorizedAsync(HttpContext ctx, IEnumerable<object> authorizationFilters)
+        {
+            if (ctx == null)
+                throw new ArgumentNullException(nameof(ctx));
+            if (authorizationFilters == null)
+                throw new ArgumentNullException(nameof(authorizationFilters));
+
+            var authFilters = authorizationFilters.ToList();
+
+            // Allow Anonymous skips all authorization
+            if (authFilters.Any(x => x is IAllowAnonymous))
+                return new ChallangeResponse {IsAuthorized = true};
+
+            // Get the authorization policy
+            var authData = authFilters.Where(x => x is IAuthorizeData).Cast<IAuthorizeData>().ToList();
+            var effectivePolicy = await AuthorizationPolicy.CombineAsync(_policyProvider, authData);
+
+            if (effectivePolicy == null)
+                return new ChallangeResponse {IsAuthorized = true};
+
+            // Build a ClaimsPrincipal with the policy's required authentication types
+            if (effectivePolicy.AuthenticationSchemes?.Any() ?? false)
+            {
+                ClaimsPrincipal newPrincipal = null;
+                foreach (var scheme in effectivePolicy.AuthenticationSchemes)
+                {
+                    var result = await ctx.Authentication.AuthenticateAsync(scheme);
+                    if (result != null)
+                    {
+                        newPrincipal = SecurityHelper.MergeUserPrincipal(newPrincipal, result);
+                    }
+                }
+                // If all schemes failed authentication, provide a default identity anyways
+                ctx.User = newPrincipal ?? new ClaimsPrincipal(new ClaimsIdentity());
+            }
+
+            var authService = ctx.RequestServices.GetRequiredService<IAuthorizationService>();
+
+            // Note: Default Anonymous User is new ClaimsPrincipal(new ClaimsIdentity())
+            var authoized = await authService.AuthorizeAsync(ctx.User, effectivePolicy);
+            return new ChallangeResponse
+            {
+                IsAuthorized = authoized,
+                AuthenticationSchemes = effectivePolicy.AuthenticationSchemes
+            };
+        }
+
+        private struct ChallangeResponse
+        {
+            public bool IsAuthorized;
+            public IReadOnlyList<string> AuthenticationSchemes;
         }
     }
 }

--- a/src/RService.IO/Providers/AuthProvider.cs
+++ b/src/RService.IO/Providers/AuthProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -30,6 +31,25 @@ namespace RService.IO.Providers
                 throw new ArgumentNullException(nameof(provider));
 
             _policyProvider = provider;
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> IsAuthorizedAsync(HttpContext ctx, ServiceMetadata metadata)
+        {
+            if (ctx == null)
+                throw new ArgumentNullException(nameof(ctx));
+            if (metadata == null)
+                throw new ArgumentNullException(nameof(metadata));
+
+            var authenticationAttributes = new List<object>();
+
+            authenticationAttributes.AddRange(metadata.Service.GetCustomAttributes<AuthorizeAttribute>());
+            authenticationAttributes.AddRange(metadata.Service.GetCustomAttributes<AllowAnonymousAttribute>());
+
+            authenticationAttributes.AddRange(metadata.Method.GetCustomAttributes<AuthorizeAttribute>());
+            authenticationAttributes.AddRange(metadata.Method.GetCustomAttributes<AllowAnonymousAttribute>());
+
+            return IsAuthorizedAsync(ctx, authenticationAttributes);
         }
 
         /// <inheritdoc/>

--- a/src/RService.IO/Providers/AuthProvider.cs
+++ b/src/RService.IO/Providers/AuthProvider.cs
@@ -45,7 +45,7 @@ namespace RService.IO.Providers
         }
 
         /// <inheritdoc/>
-        public async Task OnAuthorizationAsync(HttpContext ctx, IEnumerable<object> authorizationFilters)
+        public async Task OnChallengeAuthorizationAsync(HttpContext ctx, IEnumerable<object> authorizationFilters)
         {
             var response = await AuthorizedAsync(ctx, authorizationFilters);
             if (!response.IsAuthorized)

--- a/src/RService.IO/Providers/NetJsonProvider.cs
+++ b/src/RService.IO/Providers/NetJsonProvider.cs
@@ -12,6 +12,9 @@ using Delegate = RService.IO.Abstractions.Delegate;
 
 namespace RService.IO.Providers
 {
+    /// <summary>
+    /// Adapter for the NetJson serialization.
+    /// </summary>
     public class NetJsonProvider : ISerializationProvider
     {
         private static readonly Dictionary<Type, Dictionary<string, PropertyInfo>> CachedDtoProps = new Dictionary<Type, Dictionary<string, PropertyInfo>>();
@@ -65,6 +68,7 @@ namespace RService.IO.Providers
             return GetDtoCtorDelegate(dtoType).Invoke(reqBodyBuilder.ToString());
         }
 
+        /// <inheritdoc/>
         public string DehydrateResponse(object resDto)
         {
             return NetJSON.NetJSON.Serialize(resDto.GetType(), resDto);

--- a/src/RService.IO/Providers/RServiceProvider.cs
+++ b/src/RService.IO/Providers/RServiceProvider.cs
@@ -31,9 +31,6 @@ namespace RService.IO.Providers
             var args = new List<object>();
 
 
-
-            service.Context = context;
-
             var dto = _serializationProvider.HydrateRequest(context, dtoReqType);
             if (dto != null)
                 args.Add(dto);

--- a/src/RService.IO/Providers/RServiceProvider.cs
+++ b/src/RService.IO/Providers/RServiceProvider.cs
@@ -27,7 +27,10 @@ namespace RService.IO.Providers
             var service = context.GetServiceInstance();
             var activator = context.GetServiceMethodActivator();
             var dtoReqType = context.GetRequestDtoType();
+            var metadata = context.GetServiceMetadata();
             var args = new List<object>();
+
+
 
             service.Context = context;
 

--- a/src/RService.IO/RService.cs
+++ b/src/RService.IO/RService.cs
@@ -74,6 +74,11 @@ namespace RService.IO
                         var def = new ServiceDef
                         {
                             Ident =  Guid.NewGuid().ToString(),
+                            Metadata = new Metadata
+                            {
+                                Service = methodType.GetTypeInfo(),
+                                Method = method
+                            },
                             Route = attr,
                             ServiceType = methodType,
                             ServiceMethod = DelegateFactory.GenerateMethodCall(method),
@@ -101,6 +106,11 @@ namespace RService.IO
                         var def = new ServiceDef
                         {
                             Ident = Guid.NewGuid().ToString(),
+                            Metadata = new Metadata
+                            {
+                                Service = methodType.GetTypeInfo(),
+                                Method = method
+                            },
                             Route = route,
                             ServiceType = methodType,
                             ServiceMethod = DelegateFactory.GenerateMethodCall(method),

--- a/src/RService.IO/RService.cs
+++ b/src/RService.IO/RService.cs
@@ -71,19 +71,7 @@ namespace RService.IO
                 {
                     attr.Verbs.GetFlags().ForEach(x =>
                     {
-                        var def = new ServiceDef
-                        {
-                            Ident =  Guid.NewGuid().ToString(),
-                            Metadata = new Metadata
-                            {
-                                Service = methodType.GetTypeInfo(),
-                                Method = method
-                            },
-                            Route = attr,
-                            ServiceType = methodType,
-                            ServiceMethod = DelegateFactory.GenerateMethodCall(method),
-                            ResponseDtoType = responseType
-                        };
+                        var def = BuildServiceDef(method, methodType, attr, responseType);
                         Routes.Add(BuildCompositKey(attr.Path, x), def);
                     });
                 });
@@ -103,20 +91,7 @@ namespace RService.IO
                     var route = (RouteAttribute)a;
                     route.Verbs.GetFlags().ForEach(x =>
                     {
-                        var def = new ServiceDef
-                        {
-                            Ident = Guid.NewGuid().ToString(),
-                            Metadata = new Metadata
-                            {
-                                Service = methodType.GetTypeInfo(),
-                                Method = method
-                            },
-                            Route = route,
-                            ServiceType = methodType,
-                            ServiceMethod = DelegateFactory.GenerateMethodCall(method),
-                            RequestDtoType = paramType,
-                            ResponseDtoType = responseType
-                        };
+                        var def = BuildServiceDef(method, methodType, route, responseType, paramType);
                         Routes.Add(BuildCompositKey(route.Path, x), def);
                     });
                 });
@@ -131,6 +106,25 @@ namespace RService.IO
         protected static string CleanRoutePath(string value)
         {
             return RoutePathCleaner.Replace(value, string.Empty);
+        }
+
+        private static ServiceDef BuildServiceDef(MethodInfo method, Type service, RouteAttribute route, Type response,
+            Type request = null)
+        {
+            return new ServiceDef
+            {
+                Metadata = new ServiceMetadata
+                {
+                    Ident = Guid.NewGuid().ToString(),
+                    Service = service.GetTypeInfo(),
+                    Method = method
+                },
+                Route = route,
+                ServiceType = service,
+                ServiceMethod = DelegateFactory.GenerateMethodCall(method),
+                ResponseDtoType = response,
+                RequestDtoType = request
+            };
         }
     }
 }

--- a/src/RService.IO/RService.cs
+++ b/src/RService.IO/RService.cs
@@ -73,6 +73,7 @@ namespace RService.IO
                     {
                         var def = new ServiceDef
                         {
+                            Ident =  Guid.NewGuid().ToString(),
                             Route = attr,
                             ServiceType = methodType,
                             ServiceMethod = DelegateFactory.GenerateMethodCall(method),
@@ -99,6 +100,7 @@ namespace RService.IO
                     {
                         var def = new ServiceDef
                         {
+                            Ident = Guid.NewGuid().ToString(),
                             Route = route,
                             ServiceType = methodType,
                             ServiceMethod = DelegateFactory.GenerateMethodCall(method),

--- a/src/RService.IO/RServiceFeature.cs
+++ b/src/RService.IO/RServiceFeature.cs
@@ -6,6 +6,7 @@ namespace RService.IO
 {
     public class RServiceFeature : IRServiceFeature
     {
+        public ServiceMetadata Metadata { get; set; }
         public Delegate.Activator MethodActivator { get; set; }
         public IService Service { get; set; }
         public Type RequestDtoType { get; set; }

--- a/src/RService.IO/RServiceMiddleware.cs
+++ b/src/RService.IO/RServiceMiddleware.cs
@@ -49,6 +49,7 @@ namespace RService.IO
             {
                 context.Features[typeof(IRServiceFeature)] = new RServiceFeature
                 {
+                    Metadata = serviceDef.Metadata,
                     MethodActivator = serviceDef.ServiceMethod,
                     Service = context.RequestServices.GetService(serviceDef.ServiceType) as IService,
                     RequestDtoType = serviceDef.RequestDtoType,

--- a/src/RService.IO/RServiceMiddleware.cs
+++ b/src/RService.IO/RServiceMiddleware.cs
@@ -47,7 +47,7 @@ namespace RService.IO
             }
             else
             {
-                context.Features[typeof(IRServiceFeature)] = new RServiceFeature
+                var feature = new RServiceFeature
                 {
                     Metadata = serviceDef.Metadata,
                     MethodActivator = serviceDef.ServiceMethod,
@@ -55,6 +55,8 @@ namespace RService.IO
                     RequestDtoType = serviceDef.RequestDtoType,
                     ResponseDtoType = serviceDef.ResponseDtoType
                 };
+                feature.Service.Context = context;
+                context.Features[typeof(IRServiceFeature)] = feature;
 
                 try
                 {

--- a/src/RService.IO/RServiceMiddleware.cs
+++ b/src/RService.IO/RServiceMiddleware.cs
@@ -71,9 +71,9 @@ namespace RService.IO
                     context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 
                     // ReSharper disable once CanBeReplacedWithTryCastAndCheckForNull
-                    if (exc is ApiExceptions)
+                    if (exc is ApiException)
                     {
-                        context.Response.StatusCode = (int) ((ApiExceptions) exc).StatusCode;
+                        context.Response.StatusCode = (int) ((ApiException) exc).StatusCode;
                         await context.Response.WriteAsync(exc.Message);
                     }
 

--- a/src/RService.IO/ServiceDef.cs
+++ b/src/RService.IO/ServiceDef.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using RService.IO.Abstractions;
 using Delegate = RService.IO.Abstractions.Delegate;
 

--- a/src/RService.IO/ServiceDef.cs
+++ b/src/RService.IO/ServiceDef.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using RService.IO.Abstractions;
 using Delegate = RService.IO.Abstractions.Delegate;
 
@@ -33,5 +34,23 @@ namespace RService.IO
         /// The <see cref="Type"/> of the response dto.
         /// </summary>
         public Type ResponseDtoType;
+        /// <summary>
+        /// Metadata associated with the service and method.
+        /// </summary>
+        public Metadata Metadata;
+    }
+    /// <summary>
+    /// Metadata about a RService.IO web service.
+    /// </summary>
+    public struct Metadata
+    {
+        /// <summary>
+        /// Metadata on the service.
+        /// </summary>
+        public TypeInfo Service;
+        /// <summary>
+        /// Metadata on the method.
+        /// </summary>
+        public MethodInfo Method;
     }
 }

--- a/src/RService.IO/ServiceDef.cs
+++ b/src/RService.IO/ServiceDef.cs
@@ -4,12 +4,34 @@ using Delegate = RService.IO.Abstractions.Delegate;
 
 namespace RService.IO
 {
+    /// <summary>
+    /// Defines a RService.IO web service.
+    /// </summary>
     public struct ServiceDef
     {
+        /// <summary>
+        /// The unique identifier for this <see cref="ServiceDef"/>.
+        /// </summary>
+        public string Ident;
+        /// <summary>
+        /// The route.
+        /// </summary>
         public RouteAttribute Route;
+        /// <summary>
+        /// The service type.
+        /// </summary>
         public Type ServiceType;
+        /// <summary>
+        /// The service method activator.
+        /// </summary>
         public Delegate.Activator ServiceMethod;
+        /// <summary>
+        /// The <see cref="Type"/> of the request dto.
+        /// </summary>
         public Type RequestDtoType;
+        /// <summary>
+        /// The <see cref="Type"/> of the response dto.
+        /// </summary>
         public Type ResponseDtoType;
     }
 }

--- a/src/RService.IO/ServiceDef.cs
+++ b/src/RService.IO/ServiceDef.cs
@@ -11,10 +11,6 @@ namespace RService.IO
     public struct ServiceDef
     {
         /// <summary>
-        /// The unique identifier for this <see cref="ServiceDef"/>.
-        /// </summary>
-        public string Ident;
-        /// <summary>
         /// The route.
         /// </summary>
         public RouteAttribute Route;
@@ -37,20 +33,6 @@ namespace RService.IO
         /// <summary>
         /// Metadata associated with the service and method.
         /// </summary>
-        public Metadata Metadata;
-    }
-    /// <summary>
-    /// Metadata about a RService.IO web service.
-    /// </summary>
-    public struct Metadata
-    {
-        /// <summary>
-        /// Metadata on the service.
-        /// </summary>
-        public TypeInfo Service;
-        /// <summary>
-        /// Metadata on the method.
-        /// </summary>
-        public MethodInfo Method;
+        public ServiceMetadata Metadata;
     }
 }

--- a/src/RService.IO/project.json
+++ b/src/RService.IO/project.json
@@ -13,6 +13,7 @@
       "dotnet core",
       "ASP.NET",
       "api",
+      "RESTful",
       "RService.IO"
     ],
     "licenseUrl": "https://github.com/Stoom/RService.IO/blob/master/LICENSE",

--- a/src/RService.IO/project.json
+++ b/src/RService.IO/project.json
@@ -1,11 +1,12 @@
-{
+﻿{
   "title": "RService.IO",
   "version": "0.1.9",
-
   "packOptions": {
     "summary": "A web service framework for dotnet core loosely based on ServiceStack v3",
     "releaseNotes": "Initial alpha release",
-    "owners": [ "James Stumme" ],
+    "owners": [
+      "James Stumme"
+    ],
     "tags": [
       "microservice",
       "webservice",
@@ -22,26 +23,25 @@
       "url": "https://github.com/Stoom/RService.IO"
     }
   },
-
   "dependencies": {
+    "Microsoft.AspNetCore.Authorization": "1.0.0",
     "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0",
     "Microsoft.AspNetCore.Http": "1.0.0",
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.0",
     "Microsoft.AspNetCore.Routing": "1.0.0",
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
-    "System.ComponentModel.Primitives": "4.1.0",
-    "System.Reflection.Emit.Lightweight": "4.0.1",
+    "Microsoft.Extensions.SecurityHelper.Sources": "1.0.0-rtm-21431",
     "NetJSON": "1.2.1.4",
-    "RService.IO.Abstractions": "0.1.2"
+    "RService.IO.Abstractions": "0.1.2",
+    "System.ComponentModel.Primitives": "4.1.0",
+    "System.Reflection.Emit.Lightweight": "4.0.1"
   },
-
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.6",
         "portable-net45+win8"
       ],
-
       "dependencies": {
         "Microsoft.NETCore.App": {
           "version": "1.0.0-*",

--- a/test/RService.IO.Tests/Abstractions/RServiceHttpContextExtensionsTests.cs
+++ b/test/RService.IO.Tests/Abstractions/RServiceHttpContextExtensionsTests.cs
@@ -167,5 +167,44 @@ namespace RService.IO.Tests.Abstractions
 
             handle.Should().BeNull();
         }
+
+        [Fact]
+        public void GetMetadata__ThrowsArguementNullExceptionOnNullContext()
+        {
+            Action comparison = () => { RServiceHttpContextExtensions.GetMetadata(null); };
+
+            comparison.ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetMetadata__GeMetadataFromRServiceFeature()
+        {
+            var expectedMetadata = new ServiceMetadata();
+
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            var features = new Mock<IFeatureCollection>().SetupAllProperties();
+            var rserviceFeature = new RServiceFeature();
+            context.SetupGet(x => x.Features).Returns(features.Object);
+            features.Setup(x => x[typeof(IRServiceFeature)]).Returns(rserviceFeature);
+            rserviceFeature.Metadata = expectedMetadata;
+
+            var type = context.Object.GetMetadata();
+
+            type.Should().NotBeNull().And.Be(expectedMetadata);
+        }
+
+        [Fact]
+        public void GetMetadata__ReturnsNullIfNotRServiceFeature()
+        {
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            var features = new Mock<IFeatureCollection>().SetupAllProperties();
+            var routingFeature = new Mock<IRoutingFeature>().SetupAllProperties();
+            context.SetupGet(x => x.Features).Returns(features.Object);
+            features.Setup(x => x[typeof(IRoutingFeature)]).Returns(routingFeature.Object);
+
+            var handle = context.Object.GetMetadata();
+
+            handle.Should().BeNull();
+        }
     }
 }

--- a/test/RService.IO.Tests/Abstractions/RServiceHttpContextExtensionsTests.cs
+++ b/test/RService.IO.Tests/Abstractions/RServiceHttpContextExtensionsTests.cs
@@ -171,7 +171,7 @@ namespace RService.IO.Tests.Abstractions
         [Fact]
         public void GetMetadata__ThrowsArguementNullExceptionOnNullContext()
         {
-            Action comparison = () => { RServiceHttpContextExtensions.GetMetadata(null); };
+            Action comparison = () => { RServiceHttpContextExtensions.GetServiceMetadata(null); };
 
             comparison.ShouldThrow<ArgumentNullException>();
         }
@@ -188,7 +188,7 @@ namespace RService.IO.Tests.Abstractions
             features.Setup(x => x[typeof(IRServiceFeature)]).Returns(rserviceFeature);
             rserviceFeature.Metadata = expectedMetadata;
 
-            var type = context.Object.GetMetadata();
+            var type = context.Object.GetServiceMetadata();
 
             type.Should().NotBeNull().And.Be(expectedMetadata);
         }
@@ -202,7 +202,7 @@ namespace RService.IO.Tests.Abstractions
             context.SetupGet(x => x.Features).Returns(features.Object);
             features.Setup(x => x[typeof(IRoutingFeature)]).Returns(routingFeature.Object);
 
-            var handle = context.Object.GetMetadata();
+            var handle = context.Object.GetServiceMetadata();
 
             handle.Should().BeNull();
         }

--- a/test/RService.IO.Tests/DependencyIngection/ServiceCollectionExtensionTests.cs
+++ b/test/RService.IO.Tests/DependencyIngection/ServiceCollectionExtensionTests.cs
@@ -258,7 +258,8 @@ namespace RService.IO.Tests.DependencyIngection
             return builder.Object;
         }
 
-        public class ServiceProvider : IServiceProvider
+        // ReSharper disable ClassNeverInstantiated.Local
+        private class ServiceProvider : IServiceProvider
         {
             public Task Invoke(HttpContext context)
             {
@@ -266,7 +267,7 @@ namespace RService.IO.Tests.DependencyIngection
             }
         }
 
-        public class SeralizerProvider : ISerializationProvider
+        private class SeralizerProvider : ISerializationProvider
         {
             public string ContentType { get; } = string.Empty;
             public object HydrateRequest(HttpContext ctx, Type dtoType)

--- a/test/RService.IO.Tests/DependencyIngection/ServiceCollectionExtensionTests.cs
+++ b/test/RService.IO.Tests/DependencyIngection/ServiceCollectionExtensionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
@@ -219,6 +220,35 @@ namespace RService.IO.Tests.DependencyIngection
             globalExceptionFilter.Should().BeNull();
         }
 
+        [Fact]
+        public void AddRServiceIoAuthorization__AddsRServiceProviderForIAuthProvider()
+        {
+            var services = new ServiceCollection();
+
+            services.AddAuthorization()
+                .AddRServiceIoAuthorization();
+
+            var app = BuildApplicationBuilder(services);
+            var provider = app.ApplicationServices.GetService<IAuthProvider>();
+
+            provider.Should().NotBeNull().And.BeOfType<AuthProvider>();
+        }
+
+        [Fact]
+        public void AddRServiceIoAuthorization__UserImplementationForIAuthProviderTakesPrecedence()
+        {
+            var services = new ServiceCollection();
+
+            services.AddTransient<IAuthProvider, AuthorizationProvider>()
+                .AddAuthorization()
+                .AddRServiceIoAuthorization();
+
+            var app = BuildApplicationBuilder(services);
+            var provider = app.ApplicationServices.GetService<IAuthProvider>();
+
+            provider.Should().NotBeNull().And.BeOfType<AuthorizationProvider>();
+        }
+
         private static IApplicationBuilder BuildApplicationBuilder(IServiceCollection services)
         {
             var builder = new Mock<IApplicationBuilder>();
@@ -249,5 +279,19 @@ namespace RService.IO.Tests.DependencyIngection
                 throw new NotImplementedException();
             }
         }
+
+        private class AuthorizationProvider : IAuthProvider
+        {
+            public Task<bool> IsAuthorizedAsync(HttpContext ctx, ServiceMetadata metadata)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<bool> IsAuthorizedAsync(HttpContext ctx, IEnumerable<object> authorizationFilters)
+            {
+                throw new NotImplementedException();
+            }
+        }
+        // ReSharper restore ClassNeverInstantiated.Local
     }
 }

--- a/test/RService.IO.Tests/MockServices.cs
+++ b/test/RService.IO.Tests/MockServices.cs
@@ -1,4 +1,5 @@
-﻿using RService.IO.Abstractions;
+﻿using Microsoft.AspNetCore.Authorization;
+using RService.IO.Abstractions;
 
 namespace RService.IO.Tests
 {
@@ -34,6 +35,25 @@ namespace RService.IO.Tests
         public ResponseDto Put()
         {
             return new ResponseDto();
+        }
+    }
+
+    public class SvcAuthRoutes : ServiceBase
+    {
+        public const string AuthorizedPath = "/Auth";
+        public const string UnauthorizedPath = "/FailedAuth";
+
+        [Route(AuthorizedPath)]
+        [Authorize(Roles = "Administrator")]
+        public object Authorized()
+        {
+            return null;
+        }
+        [Route(UnauthorizedPath)]
+        [Authorize(Roles = "FakeRole")]
+        public object Unuthorized()
+        {
+            return null;
         }
     }
 

--- a/test/RService.IO.Tests/Providers/AuthProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/AuthProviderTests.cs
@@ -161,12 +161,6 @@ namespace RService.IO.Tests.Providers
             _anonymousContext.User.Should().NotBeNull();
         }
 
-        [Fact]
-        public async void IsAuthorized__AllAttributesMust()
-        {
-            
-        }
-
         private static HttpContext GetContext(Action<ServiceCollection> registerServices, bool anonymous = false)
         {
             var basicPrincipal = new ClaimsPrincipal(

--- a/test/RService.IO.Tests/Providers/AuthProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/AuthProviderTests.cs
@@ -1,7 +1,176 @@
-﻿namespace RService.IO.Tests.Providers
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using RService.IO.Abstractions;
+using RService.IO.Providers;
+using Xunit;
+
+namespace RService.IO.Tests.Providers
 {
     public class AuthProviderTests
     {
-        
+        private readonly HttpContext _anonymousContext;
+        private readonly HttpContext _authorizedContext;
+
+        public AuthProviderTests()
+        {
+            _anonymousContext = GetContext(s => s.AddTransient<IAuthProvider, AuthProvider>(), true);
+            _authorizedContext = GetContext(s => s.AddTransient<IAuthProvider, AuthProvider>());
+        }
+
+        [Fact]
+        public void InvalidUser()
+        {
+            var context = GetContext(service => service.AddAuthorization());
+            context.User.Identities.Any(x => x.IsAuthenticated).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Ctor__ThrowsExceptionIfNullProvider()
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            Action act = () => new AuthProvider(null);
+
+            act.ShouldThrow<ArgumentNullException>().And.Message.Should().Contain("provider");
+        }
+
+        [Fact]
+        public void IsAuthorizedAsync__ThrowsExceptionIfNullContext()
+        {
+            var authProvider = GetAuthProvider(_anonymousContext);
+            Func<Task> act = async () => await authProvider.IsAuthorizedAsync(null, null);
+
+            act.ShouldThrow<ArgumentNullException>().And.Message.Should().Contain("ctx");
+        }
+
+        [Fact]
+        public void IsAuthorizedAsync__ThrowsExceptionIfNullFilters()
+        {
+            var authProvider = GetAuthProvider(_anonymousContext);
+            Func<Task> act = async () => await authProvider.IsAuthorizedAsync(_anonymousContext, null);
+
+            act.ShouldThrow<ArgumentNullException>().And.Message.Should().Contain("authorizationFilter");
+        }
+
+        [Fact]
+        public async void IsAuthorizedAsync__AnonymousReturnsTrueForAnonymous()
+        {
+            var authProvider = GetAuthProvider(_anonymousContext);
+            var attributes = new[] {new AllowAnonymousAttribute()};
+
+            var results = await authProvider.IsAuthorizedAsync(_anonymousContext, attributes);
+            results.Should().BeTrue();
+        }
+
+        [Fact]
+        public async void IsAuthorizedAsync__AnonymousReturnsFalseForAuthorized()
+        {
+            var authProvider = GetAuthProvider(_anonymousContext);
+            var attributes = new[] {new AuthorizeAttribute()};
+
+            var results = await authProvider.IsAuthorizedAsync(_anonymousContext, attributes);
+            results.Should().BeFalse();
+        }
+
+        [Fact]
+        public async void IsAuthorizedAsync__AuthorizedRoleReturnsTrue()
+        {
+            var authProvider = GetAuthProvider(_authorizedContext);
+            var attributes = new[] {new AuthorizeAttribute {Roles = "Administrator"}};
+
+            var results = await authProvider.IsAuthorizedAsync(_authorizedContext, attributes);
+            results.Should().BeTrue();
+        }
+
+        [Fact]
+        public async void IsAuthorizedAsync__UnauthorizedRoleReturnsFalse()
+        {
+            var authProvider = GetAuthProvider(_authorizedContext);
+            var attributes = new[] {new AuthorizeAttribute {Roles = "Poweruser"}};
+
+            var results = await authProvider.IsAuthorizedAsync(_authorizedContext, attributes);
+            results.Should().BeFalse();
+        }
+
+        [Fact]
+        public async void IsAuthorized__AuthoriedWithNoAttributes()
+        {
+            var authProvider = GetAuthProvider(_authorizedContext);
+            var attributes = new object[] {};
+
+            var results = await authProvider.IsAuthorizedAsync(_authorizedContext, attributes);
+            results.Should().BeTrue();
+        }
+
+        [Fact]
+        public async void IsAuthorized__AllAttributesMust()
+        {
+            
+        }
+
+        private static HttpContext GetContext(Action<ServiceCollection> registerServices, bool anonymous = false)
+        {
+            var basicPrincipal = new ClaimsPrincipal(
+                new ClaimsIdentity(new[]
+                    {
+                        new Claim("Permission", "CanViewPage"),
+                        new Claim(ClaimTypes.Role, "Administrator"),
+                        new Claim(ClaimTypes.Role, "User"),
+                        new Claim(ClaimTypes.NameIdentifier, "John"),
+                    },
+                    "Basic"
+                ));
+
+            var validUser = basicPrincipal;
+
+            var bearerIdentity = new ClaimsIdentity(new[]
+                {
+                    new Claim("Permission", "CupBearer"),
+                    new Claim(ClaimTypes.Role, "Token"),
+                    new Claim(ClaimTypes.NameIdentifier, "Jon Bear")
+                },
+                "Bearer"
+            );
+            var bearerPrincipal = new ClaimsPrincipal(bearerIdentity);
+
+            validUser.AddIdentity(bearerIdentity);
+
+            var serviceCollection = new ServiceCollection();
+            if (registerServices != null)
+            {
+                serviceCollection.AddOptions();
+                serviceCollection.AddLogging();
+                serviceCollection.AddAuthorization();
+
+                registerServices.Invoke(serviceCollection);
+            }
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var context = new Mock<HttpContext>();
+            var auth = new Mock<AuthenticationManager>();
+            context.Setup(x => x.Authentication).Returns(auth.Object);
+            context.SetupProperty(x => x.User);
+            if (!anonymous)
+                context.Object.User = validUser;
+            context.SetupGet(x => x.RequestServices).Returns(serviceProvider);
+            auth.Setup(x => x.AuthenticateAsync("Bearer")).ReturnsAsync(bearerPrincipal);
+            auth.Setup(x => x.AuthenticateAsync("Basic")).ReturnsAsync(basicPrincipal);
+            auth.Setup(x => x.AuthenticateAsync("Fails")).ReturnsAsync(null);
+
+            return context.Object;
+        }
+
+        private IAuthProvider GetAuthProvider(HttpContext ctx)
+        {
+            return ctx.RequestServices.GetRequiredService<IAuthProvider>();
+        }
     }
 }

--- a/test/RService.IO.Tests/Providers/AuthProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/AuthProviderTests.cs
@@ -110,6 +110,58 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
+        public async void IsAuthorized__AuthorizedWithSpecifiedScheme()
+        {
+            var authProvider = GetAuthProvider(_authorizedContext);
+            var attributes = new[]
+            {
+                new AuthorizeAttribute
+                {
+                    Roles = "Administrator",
+                    ActiveAuthenticationSchemes = "Basic"
+                }
+            };
+
+            var results = await authProvider.IsAuthorizedAsync(_authorizedContext, attributes);
+            results.Should().BeTrue();
+        }
+
+        [Fact]
+        public async void IsAuthorized__NotAuthorizedWithSpecifiedMissingScheme()
+        {
+            var authProvider = GetAuthProvider(_authorizedContext);
+            var attributes = new[]
+            {
+                new AuthorizeAttribute
+                {
+                    Roles = "Administrator",
+                    ActiveAuthenticationSchemes = "FizzBuzzScheme"
+                }
+            };
+
+            var results = await authProvider.IsAuthorizedAsync(_authorizedContext, attributes);
+            results.Should().BeFalse();
+        }
+
+        [Fact]
+        public async void IsAuthorized__ProvideDefaultIdentityIfClaimsFails()
+        {
+            var authProvider = GetAuthProvider(_anonymousContext);
+            var attributes = new[]
+            {
+                new AuthorizeAttribute
+                {
+                    Roles = "Administrator",
+                    ActiveAuthenticationSchemes = "Basic"
+                }
+            };
+
+            _anonymousContext.User.Should().BeNull();
+            await authProvider.IsAuthorizedAsync(_anonymousContext, attributes);
+            _anonymousContext.User.Should().NotBeNull();
+        }
+
+        [Fact]
         public async void IsAuthorized__AllAttributesMust()
         {
             
@@ -168,7 +220,7 @@ namespace RService.IO.Tests.Providers
             return context.Object;
         }
 
-        private IAuthProvider GetAuthProvider(HttpContext ctx)
+        private static IAuthProvider GetAuthProvider(HttpContext ctx)
         {
             return ctx.RequestServices.GetRequiredService<IAuthProvider>();
         }

--- a/test/RService.IO.Tests/Providers/AuthProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/AuthProviderTests.cs
@@ -100,7 +100,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public async void IsAuthorized__AuthoriedWithNoAttributes()
+        public async void IsAuthorizedAsync__AuthoriedWithNoAttributes()
         {
             var authProvider = GetAuthProvider(_authorizedContext);
             var attributes = new object[] {};
@@ -110,7 +110,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public async void IsAuthorized__AuthorizedWithSpecifiedScheme()
+        public async void IsAuthorizedAsync__AuthorizedWithSpecifiedScheme()
         {
             var authProvider = GetAuthProvider(_authorizedContext);
             var attributes = new[]
@@ -127,7 +127,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public async void IsAuthorized__NotAuthorizedWithSpecifiedMissingScheme()
+        public async void IsAuthorizedAsync__NotAuthorizedWithSpecifiedMissingScheme()
         {
             var authProvider = GetAuthProvider(_authorizedContext);
             var attributes = new[]
@@ -144,7 +144,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public async void IsAuthorized__ProvideDefaultIdentityIfClaimsFails()
+        public async void IsAuthorizedAsync__ProvideDefaultIdentityIfClaimsFails()
         {
             var authProvider = GetAuthProvider(_anonymousContext);
             var attributes = new[]
@@ -162,7 +162,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public async void IsAuthorized__AuthorizedWhenSpecifingMultipleRolesInSingleAttr()
+        public async void IsAuthorizedAsync__AuthorizedWhenSpecifingMultipleRolesInSingleAttr()
         {
             var authProvider = GetAuthProvider(_authorizedContext);
             var attributes = new[] { new AuthorizeAttribute { Roles = "Administrator, PowerUser" } };
@@ -172,7 +172,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public async void IsAuthorized__AuthorizedRequireAllAttrToBeAuthorized()
+        public async void IsAuthorizedAsync__AuthorizedRequireAllAttrToBeAuthorized()
         {
             var authProvider = GetAuthProvider(_authorizedContext);
             var attributes = new[]

--- a/test/RService.IO.Tests/Providers/AuthProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/AuthProviderTests.cs
@@ -161,6 +161,30 @@ namespace RService.IO.Tests.Providers
             _anonymousContext.User.Should().NotBeNull();
         }
 
+        [Fact]
+        public async void IsAuthorized__AuthorizedWhenSpecifingMultipleRolesInSingleAttr()
+        {
+            var authProvider = GetAuthProvider(_authorizedContext);
+            var attributes = new[] { new AuthorizeAttribute { Roles = "Administrator, PowerUser" } };
+
+            var results = await authProvider.IsAuthorizedAsync(_authorizedContext, attributes);
+            results.Should().BeTrue();
+        }
+
+        [Fact]
+        public async void IsAuthorized__AuthorizedRequireAllAttrToBeAuthorized()
+        {
+            var authProvider = GetAuthProvider(_authorizedContext);
+            var attributes = new[]
+            {
+                new AuthorizeAttribute { Roles = "Administrator" },
+                new AuthorizeAttribute { Roles = "PowerUser" }
+            };
+
+            var results = await authProvider.IsAuthorizedAsync(_authorizedContext, attributes);
+            results.Should().BeFalse();
+        }
+
         private static HttpContext GetContext(Action<ServiceCollection> registerServices, bool anonymous = false)
         {
             var basicPrincipal = new ClaimsPrincipal(

--- a/test/RService.IO.Tests/Providers/AuthProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/AuthProviderTests.cs
@@ -1,0 +1,7 @@
+﻿namespace RService.IO.Tests.Providers
+{
+    public class AuthProviderTests
+    {
+        
+    }
+}

--- a/test/RService.IO.Tests/Providers/AuthZProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/AuthZProviderTests.cs
@@ -1,0 +1,7 @@
+﻿namespace RService.IO.Tests.Providers
+{
+    public class AuthZProviderTests
+    {
+        
+    }
+}

--- a/test/RService.IO.Tests/Providers/AuthZProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/AuthZProviderTests.cs
@@ -1,7 +1,0 @@
-﻿namespace RService.IO.Tests.Providers
-{
-    public class AuthZProviderTests
-    {
-        
-    }
-}

--- a/test/RService.IO.Tests/Providers/RServiceProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/RServiceProviderTests.cs
@@ -19,6 +19,7 @@ namespace RService.IO.Tests.Providers
         private readonly RService _rservice;
         private RServiceProvider _provider;
         private Mock<ISerializationProvider> _serializationProvider;
+        private Mock<IAuthProvider> _authProvider;
 
         public RServiceProviderTests()
         {
@@ -35,11 +36,12 @@ namespace RService.IO.Tests.Providers
         private void Init()
         {
             _serializationProvider = new Mock<ISerializationProvider>();
-            _provider = new RServiceProvider(_serializationProvider.Object);
+            _authProvider = new Mock<IAuthProvider>();
+            _provider = new RServiceProvider(_serializationProvider.Object, _authProvider.Object);
         }
 
         [Fact]
-        public void ServiceHandler__CallsServiceMethod()
+        public void Invoke__CallsServiceMethod()
         {
             Init();
 
@@ -54,7 +56,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public void ServiceHandler__WritesStringResponseToContextResponse()
+        public void Invoke__WritesStringResponseToContextResponse()
         {
             Init();
 
@@ -72,7 +74,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public void ServiceHandler__WritesPrimitiveResponseToContextResponse()
+        public void Invoke__WritesPrimitiveResponseToContextResponse()
         {
             Init();
 
@@ -90,7 +92,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public void ServiceHandler__WritesEmptyStringIfServiceMethodReturnsNull()
+        public void Invoke__WritesEmptyStringIfServiceMethodReturnsNull()
         {
             Init();
 
@@ -108,7 +110,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public void ServiceHandler__SerializesResponseDto()
+        public void Invoke__SerializesResponseDto()
         {
             Init();
 
@@ -132,7 +134,7 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
-        public void ServiceHandler__SetsContextOfService()
+        public void Invoke__SetsContextOfService()
         {
             Init();
 

--- a/test/RService.IO.Tests/Providers/RServiceProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/RServiceProviderTests.cs
@@ -19,7 +19,6 @@ namespace RService.IO.Tests.Providers
         private readonly RService _rservice;
         private RServiceProvider _provider;
         private Mock<ISerializationProvider> _serializationProvider;
-        private Mock<IAuthProvider> _authProvider;
 
         public RServiceProviderTests()
         {
@@ -36,8 +35,7 @@ namespace RService.IO.Tests.Providers
         private void Init()
         {
             _serializationProvider = new Mock<ISerializationProvider>();
-            _authProvider = new Mock<IAuthProvider>();
-            _provider = new RServiceProvider(_serializationProvider.Object, _authProvider.Object);
+            _provider = new RServiceProvider(_serializationProvider.Object);
         }
 
         [Fact]

--- a/test/RService.IO.Tests/Providers/RServiceProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/RServiceProviderTests.cs
@@ -32,10 +32,7 @@ namespace RService.IO.Tests.Providers
                 })
             });
             _rservice = new RService(options);
-        }
 
-        private void Init()
-        {
             _serializationProvider = new Mock<ISerializationProvider>();
             _provider = new RServiceProvider(_serializationProvider.Object);
         }
@@ -43,8 +40,6 @@ namespace RService.IO.Tests.Providers
         [Fact]
         public async void Invoke__CallsServiceMethod()
         {
-            Init();
-
             var service = new SvcWithMethodRoute();
             var routePath = SvcWithMethodRoute.RoutePath.Substring(1);
 
@@ -58,8 +53,6 @@ namespace RService.IO.Tests.Providers
         [Fact]
         public void Invoke__WritesStringResponseToContextResponse()
         {
-            Init();
-
             var service = new SvcWithMethodRoute { GetResponse = "Foobar" };
             var routePath = SvcWithMethodRoute.GetPath.Substring(1);
 
@@ -76,8 +69,6 @@ namespace RService.IO.Tests.Providers
         [Fact]
         public void Invoke__WritesPrimitiveResponseToContextResponse()
         {
-            Init();
-
             var service = new SvcWithMethodRoute { PostResponse = 100 };
             var routePath = SvcWithMethodRoute.PostPath.Substring(1);
 
@@ -94,8 +85,6 @@ namespace RService.IO.Tests.Providers
         [Fact]
         public void Invoke__WritesEmptyStringIfServiceMethodReturnsNull()
         {
-            Init();
-
             var service = new SvcWithMethodRoute { GetResponse = null };
             var routePath = SvcWithMethodRoute.GetPath.Substring(1);
 
@@ -112,8 +101,6 @@ namespace RService.IO.Tests.Providers
         [Fact]
         public void Invoke__SerializesResponseDto()
         {
-            Init();
-
             const string expectedValue = "FizzBuzz";
             var service = new SvcWithMethodRoute();
             var routePath = SvcWithMethodRoute.RoutePath.Substring(1);
@@ -136,8 +123,6 @@ namespace RService.IO.Tests.Providers
         [Fact]
         public void Invoke__DoesNotThrowsExceptionIfNullAuthProvider()
         {
-            Init();
-
             var service = new SvcWithMethodRoute();
             var routePath = SvcWithMethodRoute.RoutePath.Substring(1);
 
@@ -158,8 +143,6 @@ namespace RService.IO.Tests.Providers
         [Fact]
         public void Invoke__ThrowsExceptionIfNotAuthorized()
         {
-            Init();
-
             var service = new SvcWithMethodRoute();
             var routePath = SvcWithMethodRoute.RoutePath.Substring(1);
 
@@ -180,8 +163,6 @@ namespace RService.IO.Tests.Providers
         [Fact]
         public void Invoke__DoesNotThrowsExceptionIfAuthorized()
         {
-            Init();
-
             var service = new SvcWithMethodRoute();
             var routePath = SvcWithMethodRoute.RoutePath.Substring(1);
 

--- a/test/RService.IO.Tests/RServiceMiddlewareTests.cs
+++ b/test/RService.IO.Tests/RServiceMiddlewareTests.cs
@@ -182,7 +182,7 @@ namespace RService.IO.Tests
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
             provider.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
-                .Throws(new ApiExceptions(expectedBody, expectedStatusCode));
+                .Throws(new ApiException(expectedBody, expectedStatusCode));
 
             var routeData = BuildRouteData(routePath);
             var context = BuildContext(routeData, ctx => Task.FromResult(0));
@@ -214,7 +214,7 @@ namespace RService.IO.Tests
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
             provider.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
-                .Throws(new ApiExceptions(string.Empty, expectedStatusCode));
+                .Throws(new ApiException(string.Empty, expectedStatusCode));
 
             var routeData = BuildRouteData(routePath);
             var context = BuildContext(routeData, ctx => Task.FromResult(0));
@@ -347,7 +347,7 @@ namespace RService.IO.Tests
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
             provider.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
-                .Throws<ApiExceptions>();
+                .Throws<ApiException>();
 
             var routeData = BuildRouteData(routePath);
             var context = BuildContext(routeData, ctx => Task.FromResult(0));
@@ -361,7 +361,7 @@ namespace RService.IO.Tests
                 await middleware.Invoke(context);
             };
 
-            act.ShouldThrow<ApiExceptions>();
+            act.ShouldThrow<ApiException>();
         }
 
         private static RouteData BuildRouteData(string path)

--- a/test/RService.IO.Tests/RServiceTests.cs
+++ b/test/RService.IO.Tests/RServiceTests.cs
@@ -123,6 +123,16 @@ namespace RService.IO.Tests
         }
 
         [Fact]
+        public void Ctor__AddsUniqueIdentForEachRoute()
+        {
+            var service = new RService(_options);
+
+            var idents = service.Routes.Values.Select(x => x.Ident).Where(y => y != null).ToList();
+            idents.Count.Should().Be(service.Routes.Count, "Service method(s) missing ident.");
+            idents.Duplicates().Should().BeEmpty();
+        }
+
+        [Fact]
         public void Ctor__ScansAssembliesForSerivceTypes()
         {
             var expectedServiceType = typeof(SvcWithMethodRoute);

--- a/test/RService.IO.Tests/RServiceTests.cs
+++ b/test/RService.IO.Tests/RServiceTests.cs
@@ -128,7 +128,7 @@ namespace RService.IO.Tests
         {
             var service = new RService(_options);
 
-            var idents = service.Routes.Values.Select(x => x.Ident).Where(y => y != null).ToList();
+            var idents = service.Routes.Values.Select(x => x.Metadata.Ident).Where(y => y != null).ToList();
             idents.Count.Should().Be(service.Routes.Count, "Service method(s) missing ident.");
             idents.Duplicates().Should().BeEmpty();
         }
@@ -144,8 +144,8 @@ namespace RService.IO.Tests
 
             var service = new RService(_options);
 
-            service.Routes[expectedPath].Metadata.Service.Should().BeSameAs(typeof(SvcWithMethodRoute).GetTypeInfo());
-            service.Routes[expectedPath].Metadata.Method.Should().BeSameAs(expectedMethodMetadata);
+            service.Routes[expectedPath].Metadata?.Service.Should().BeSameAs(typeof(SvcWithMethodRoute).GetTypeInfo());
+            service.Routes[expectedPath].Metadata?.Method.Should().BeSameAs(expectedMethodMetadata);
         }
 
         [Fact]
@@ -159,8 +159,8 @@ namespace RService.IO.Tests
 
             var service = new RService(_options);
 
-            service.Routes[expectedPath].Metadata.Service.Should().BeSameAs(typeof(SvcWithParamRoute).GetTypeInfo());
-            service.Routes[expectedPath].Metadata.Method.Should().BeSameAs(expectedMethodMetadata);
+            service.Routes[expectedPath].Metadata?.Service.Should().BeSameAs(typeof(SvcWithParamRoute).GetTypeInfo());
+            service.Routes[expectedPath].Metadata?.Method.Should().BeSameAs(expectedMethodMetadata);
         }
 
         [Fact]

--- a/test/RService.IO.Tests/UtilsEx.cs
+++ b/test/RService.IO.Tests/UtilsEx.cs
@@ -29,5 +29,17 @@ namespace RService.IO.Tests
                 return middleware;
             }).ToList();
         }
+
+        public static IEnumerable<TValue> Duplicates<TValue>(this IEnumerable<TValue> source)
+        {
+            return source.Duplicates(x => x.Key);
+        }
+
+        public static IEnumerable<TResults> Duplicates<TValue, TResults>(this IEnumerable<TValue> source, Func<IGrouping<TValue, TValue>, TResults> predicate)
+        {
+            return source.GroupBy(x => x)
+                .Where(g => g.Count() > 1)
+                .Select(predicate);
+        }
     }
 }


### PR DESCRIPTION
Adds authorization support for endpoints and services.

Users must add the following to activate authorization.  If they do not then `Authorize` attribues are ignored.
```csharp
public void ConfigureServices(IServiceCollection services)
{
    ...

    services.AddAuthorization()
        .AddRServiceIoAuthorization();
}
```

Note the `AddRServiceIoAuthorization()`.