### PR TITLE
Void endpoint method support

### DIFF
--- a/src/RService.IO/DelegateFactory.cs
+++ b/src/RService.IO/DelegateFactory.cs
@@ -22,11 +22,32 @@ namespace RService.IO
 
             var instance = Expression.Parameter(typeof(object), "target");
             var arguments = Expression.Parameter(typeof(object[]), "arguments");
-            var call = Expression.Call(
-                Expression.Convert(instance, methodType),
-                method,
-                CreateParameterExpressions(method, arguments)
+
+            Expression call;
+            if (method.ReturnType != typeof(void))
+            {
+                call = Expression.Call(
+                    Expression.Convert(instance, methodType),
+                    method,
+                    CreateParameterExpressions(method, arguments)
                 );
+            }
+            else
+            {
+                // Constants
+                var nullConst = Expression.Constant(null, typeof(object));
+
+                // Return
+                var returnTarget = Expression.Label(typeof(object), "Void return target");
+                var returnLable = Expression.Label(returnTarget, nullConst);
+
+                call = Expression.Block(
+                    Expression.Call(
+                        Expression.Convert(instance, methodType),
+                        method,
+                        CreateParameterExpressions(method, arguments)),
+                    returnLable);
+            }
             var lambda = Expression.Lambda<Delegate.Activator>(
                 Expression.Convert(call, typeof(object)),
                 instance,

--- a/src/RService.IO/Providers/RServiceProvider.cs
+++ b/src/RService.IO/Providers/RServiceProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;

--- a/test/RService.IO.Tests/MockServices.cs
+++ b/test/RService.IO.Tests/MockServices.cs
@@ -8,15 +8,15 @@ namespace RService.IO.Tests
         public const string RoutePath = "/Foobar";
         public const string GetPath = "/Foobar/Method";
         public const string PostPath = "/Foobar/Method";
+        public const string VoidPath = "/Foobar/Void";
         public bool HasAnyBeenCalled { get; set; }
         public string GetResponse { get; set; }
         public int PostResponse { get; set; }
 
         [Route(RoutePath, RestVerbs.Get)]
-        public object Any()
+        public void Any()
         {
             HasAnyBeenCalled = true;
-            return null;
         }
 
         [Route(GetPath, RestVerbs.Get)]
@@ -36,6 +36,11 @@ namespace RService.IO.Tests
         {
             return new ResponseDto();
         }
+
+        [Route(VoidPath, RestVerbs.Get)]
+        public void VoidEndpoint()
+        {
+        }
     }
 
     public class SvcAuthRoutes : ServiceBase
@@ -45,15 +50,13 @@ namespace RService.IO.Tests
 
         [Route(AuthorizedPath)]
         [Authorize(Roles = "Administrator")]
-        public object Authorized()
+        public void Authorized()
         {
-            return null;
         }
         [Route(UnauthorizedPath)]
         [Authorize(Roles = "FakeRole")]
-        public object Unuthorized()
+        public void Unuthorized()
         {
-            return null;
         }
     }
 
@@ -62,9 +65,8 @@ namespace RService.IO.Tests
         public const string Path = "/SvcBase";
 
         [Route(Path)]
-        public object Any()
+        public void Any()
         {
-            return null;
         }
     }
 
@@ -75,9 +77,8 @@ namespace RService.IO.Tests
 
         [Route(RoutePath1, RestVerbs.Get)]
         [Route(RoutePath2, RestVerbs.Get)]
-        public object Any()
+        public void Any()
         {
-            return null;
         }
     }
 
@@ -114,9 +115,8 @@ namespace RService.IO.Tests
         public const string RoutePath1 = "/Llamas/Eats";
         public const string RoutePath2 = "/Llamas/Hands";
 
-        public object Any(DtoForMultParamRoutes dto)
+        public void Any(DtoForMultParamRoutes dto)
         {
-            return null;
         }
     }
 
@@ -129,15 +129,13 @@ namespace RService.IO.Tests
         public const RestVerbs MultiMethod = RestVerbs.Get | RestVerbs.Post;
 
         [Route(PostPath, PostMethod)]
-        public object Post()
+        public void Post()
         {
-            return null;
         }
 
         [Route(MultiPath, MultiMethod)]
-        public object GetPost()
+        public void GetPost()
         {
-            return null;
         }
     }
 

--- a/test/RService.IO.Tests/Providers/RServiceProviderTests.cs
+++ b/test/RService.IO.Tests/Providers/RServiceProviderTests.cs
@@ -99,6 +99,22 @@ namespace RService.IO.Tests.Providers
         }
 
         [Fact]
+        public void Invoke__WritesEmptyStringIfServiceMethodTypeIsVoid()
+        {
+            var service = new SvcWithMethodRoute();
+            var routePath = SvcWithMethodRoute.VoidPath.Substring(1);
+
+            var context = BuildContext(routePath, service);
+            var body = context.Object.Response.Body;
+
+            _provider.Invoke(context.Object).Wait(5000);
+            body.Position = 0;
+
+            using (var reader = new StreamReader(body))
+                reader.ReadToEnd().Should().Be(string.Empty);
+        }
+
+        [Fact]
         public void Invoke__SerializesResponseDto()
         {
             const string expectedValue = "FizzBuzz";


### PR DESCRIPTION
Adds support for void endpoint methods.  The user no longer needs to use the following:
```csharp
public object Name()
{
  return null;
}
```

Instead they can now simply use:
```csharp
public void Name()
{
}
```