### PR TITLE
Make serialization providers extensible

### DIFF
--- a/src/RService.IO.Abstractions/HttpContentTypes.cs
+++ b/src/RService.IO.Abstractions/HttpContentTypes.cs
@@ -2,6 +2,7 @@
 {
     public static class HttpContentTypes
     {
+        public const string Any = "*/*";
         public const string ApplicationJson = "application/json";
     }
 }

--- a/src/RService.IO.Abstractions/IRServiceFeature.cs
+++ b/src/RService.IO.Abstractions/IRServiceFeature.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using RService.IO.Abstractions.Providers;
 
 namespace RService.IO.Abstractions
 {
@@ -9,5 +10,7 @@ namespace RService.IO.Abstractions
         IService Service { get; set; }
         Type RequestDtoType { get; set; }
         Type ResponseDtoType { get; set; }
+        ISerializationProvider RequestSerializer { get; set; }
+        ISerializationProvider ResponseSerializer { get; set; }
     }
 }

--- a/src/RService.IO.Abstractions/RServiceHttpContextExtensions.cs
+++ b/src/RService.IO.Abstractions/RServiceHttpContextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.AspNetCore.Http;
+using RService.IO.Abstractions.Providers;
 
 namespace RService.IO.Abstractions
 {
@@ -45,6 +46,24 @@ namespace RService.IO.Abstractions
                 throw new ArgumentNullException(nameof(context));
             var feature = context.Features[typeof(IRServiceFeature)] as IRServiceFeature;
             return feature?.Metadata;
+        }
+
+        public static ISerializationProvider GetRequestSerializationProvider(this HttpContext context)
+        {
+
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            var feature = context.Features[typeof(IRServiceFeature)] as IRServiceFeature;
+            return feature?.RequestSerializer;
+        }
+
+        public static ISerializationProvider GetResponseSerializationProvider(this HttpContext context)
+        {
+
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            var feature = context.Features[typeof(IRServiceFeature)] as IRServiceFeature;
+            return feature?.ResponseSerializer;
         }
     }
 }

--- a/src/RService.IO/DependencyIngection/ServiceCollectionExtensions.cs
+++ b/src/RService.IO/DependencyIngection/ServiceCollectionExtensions.cs
@@ -32,10 +32,18 @@ namespace RService.IO.DependencyIngection
             services.TryAddTransient<IServiceProvider, RServiceProvider>();
 
             services.AddSingleton<RService>();
-            services.Configure(rserviceOptions);
+            Action<RServiceOptions> defaultOptions = opts =>
+            {
+                rserviceOptions(opts);
+
+                opts.DefaultSerializationProvider = opts.DefaultSerializationProvider ?? new NetJsonProvider();
+                if (!opts.SerializationProviders.ContainsKey(opts.DefaultSerializationProvider.ContentType))
+                    opts.SerializationProviders.Add(opts.DefaultSerializationProvider.ContentType, opts.DefaultSerializationProvider);
+            };
+            services.Configure(defaultOptions);
 
             var options = new RServiceOptions();
-            rserviceOptions(options);
+            defaultOptions(options);
 
             if (options.ExceptionFilter != null)
                 services.AddScoped(typeof(IExceptionFilter), options.ExceptionFilter.GetType());

--- a/src/RService.IO/DependencyIngection/ServiceCollectionExtensions.cs
+++ b/src/RService.IO/DependencyIngection/ServiceCollectionExtensions.cs
@@ -28,7 +28,6 @@ namespace RService.IO.DependencyIngection
             services.AddOptions();
             services.AddRouting(routeOptions);
 
-            services.TryAddTransient<ISerializationProvider, NetJsonProvider>();
             services.TryAddTransient<IServiceProvider, RServiceProvider>();
 
             services.AddSingleton<RService>();

--- a/src/RService.IO/RServiceFeature.cs
+++ b/src/RService.IO/RServiceFeature.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using RService.IO.Abstractions;
+using RService.IO.Abstractions.Providers;
 using Delegate = RService.IO.Abstractions.Delegate;
 
 namespace RService.IO
@@ -11,5 +12,7 @@ namespace RService.IO
         public IService Service { get; set; }
         public Type RequestDtoType { get; set; }
         public Type ResponseDtoType { get; set; }
+        public ISerializationProvider RequestSerializer { get; set; }
+        public ISerializationProvider ResponseSerializer { get; set; }
     }
 }

--- a/src/RService.IO/RServiceMiddleware.cs
+++ b/src/RService.IO/RServiceMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;

--- a/src/RService.IO/RServiceMiddleware.cs
+++ b/src/RService.IO/RServiceMiddleware.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -7,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RService.IO.Abstractions;
+using RService.IO.Abstractions.Providers;
 using IServiceProvider = RService.IO.Abstractions.Providers.IServiceProvider;
 
 namespace RService.IO
@@ -46,19 +49,40 @@ namespace RService.IO
             }
             else
             {
-                var feature = new RServiceFeature
-                {
-                    Metadata = serviceDef.Metadata,
-                    MethodActivator = serviceDef.ServiceMethod,
-                    Service = context.RequestServices.GetService(serviceDef.ServiceType) as IService,
-                    RequestDtoType = serviceDef.RequestDtoType,
-                    ResponseDtoType = serviceDef.ResponseDtoType
-                };
-                feature.Service.Context = context;
-                context.Features[typeof(IRServiceFeature)] = feature;
-
                 try
                 {
+                    var req = context.Request;
+
+                    if (req.ContentLength > 0 && (req.ContentType == null
+                                                  || !_options.SerializationProviders.ContainsKey(req.ContentType)))
+                        throw new ApiException(HttpStatusCode.UnsupportedMediaType);
+
+                    ISerializationProvider responseSerializer = null;
+                    var acceptHeader = req.Headers["Accept"];
+                    
+                    if (acceptHeader.Count > 0 && acceptHeader.TakeWhile(header => !_options.SerializationProviders
+                            .TryGetValue(header, out responseSerializer))
+                            .Any(header => header == HttpContentTypes.Any))
+                        responseSerializer = _options.DefaultSerializationProvider;
+
+                    if (responseSerializer == null)
+                        throw new ApiException(HttpStatusCode.NotAcceptable);
+
+                    var feature = new RServiceFeature
+                    {
+                        Metadata = serviceDef.Metadata,
+                        MethodActivator = serviceDef.ServiceMethod,
+                        Service = context.RequestServices.GetService(serviceDef.ServiceType) as IService,
+                        RequestDtoType = serviceDef.RequestDtoType,
+                        ResponseDtoType = serviceDef.ResponseDtoType,
+                        RequestSerializer = req.ContentType != null
+                            ? _options.SerializationProviders[req.ContentType]
+                            : null,
+                        ResponseSerializer = responseSerializer
+                    };
+                    feature.Service.Context = context;
+                    context.Features[typeof(IRServiceFeature)] = feature;
+
                     await _serviceProvider.Invoke(context);
                 }
                 catch (Exception exc)
@@ -67,7 +91,7 @@ namespace RService.IO
                         throw;
 
                     context.Response.Clear();
-                    context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                    context.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
 
                     // ReSharper disable once CanBeReplacedWithTryCastAndCheckForNull
                     if (exc is ApiException)

--- a/src/RService.IO/RServiceMiddleware.cs
+++ b/src/RService.IO/RServiceMiddleware.cs
@@ -52,7 +52,7 @@ namespace RService.IO
                 {
                     var req = context.Request;
 
-                    if (req.ContentLength > 0 && (req.ContentType == null
+                    if (req.ContentLength > 0 && (string.IsNullOrWhiteSpace(req.ContentType)
                                                   || !_options.SerializationProviders.ContainsKey(req.ContentType)))
                         throw new ApiException(HttpStatusCode.UnsupportedMediaType);
 

--- a/src/RService.IO/RServiceOptions.cs
+++ b/src/RService.IO/RServiceOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using RService.IO.Abstractions;
+using RService.IO.Abstractions.Providers;
 
 namespace RService.IO
 {
@@ -28,6 +29,11 @@ namespace RService.IO
         /// Assemblies containing RServiceIO services.
         /// </summary>
         public List<Assembly> ServiceAssemblies { get; set; } = new List<Assembly>();
+
+        public IDictionary<string, ISerializationProvider> SerializationProviders { get; set; } =
+            new Dictionary<string, ISerializationProvider>();
+
+        public ISerializationProvider DefaultSerializationProvider { get; set; }
 
         /// <summary>
         /// Adds an <see cref="Assembly"/> based on a service <see cref="Type"/>.

--- a/test/RService.IO.Authorization.Tests/RService.IO.Authorization.Tests.xproj
+++ b/test/RService.IO.Authorization.Tests/RService.IO.Authorization.Tests.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{44B66719-E3DC-4F39-A67D-196BCB9A0FA7}</ProjectGuid>
@@ -14,9 +13,11 @@
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/RService.IO.Tests/Abstractions/RServiceHttpContextExtensionsTests.cs
+++ b/test/RService.IO.Tests/Abstractions/RServiceHttpContextExtensionsTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Moq;
 using RService.IO.Abstractions;
+using RService.IO.Abstractions.Providers;
 using Xunit;
 using Delegate = RService.IO.Abstractions.Delegate;
 
@@ -203,6 +204,84 @@ namespace RService.IO.Tests.Abstractions
             features.Setup(x => x[typeof(IRoutingFeature)]).Returns(routingFeature.Object);
 
             var handle = context.Object.GetServiceMetadata();
+
+            handle.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetRequestSerializationProvider__ThrowsArguementNullExceptionOnNullContext()
+        {
+            Action comparison = () => { RServiceHttpContextExtensions.GetRequestSerializationProvider(null); };
+
+            comparison.ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetRequestSerializationProvider__GetRequestSerializationProviderFromRServiceFeature()
+        {
+            var expectedProvider = new Mock<ISerializationProvider>();
+
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            var features = new Mock<IFeatureCollection>().SetupAllProperties();
+            var rserviceFeature = new RServiceFeature();
+            context.SetupGet(x => x.Features).Returns(features.Object);
+            features.Setup(x => x[typeof(IRServiceFeature)]).Returns(rserviceFeature);
+            rserviceFeature.RequestSerializer = expectedProvider.Object;
+
+            var requestSerializationProvider = context.Object.GetRequestSerializationProvider();
+
+            requestSerializationProvider.Should().NotBeNull().And.Be(expectedProvider.Object);
+        }
+
+        [Fact]
+        public void GetRequestSerializationProvider__ReturnsNullIfNotRServiceFeature()
+        {
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            var features = new Mock<IFeatureCollection>().SetupAllProperties();
+            var routingFeature = new Mock<IRoutingFeature>().SetupAllProperties();
+            context.SetupGet(x => x.Features).Returns(features.Object);
+            features.Setup(x => x[typeof(IRoutingFeature)]).Returns(routingFeature.Object);
+
+            var handle = context.Object.GetRequestSerializationProvider();
+
+            handle.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetResponseSerializationProvider__ThrowsArguementNullExceptionOnNullContext()
+        {
+            Action comparison = () => { RServiceHttpContextExtensions.GetResponseSerializationProvider(null); };
+
+            comparison.ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetResponseSerializationProvider__GetResponseSerializationProviderFromRServiceFeature()
+        {
+            var expectedProvider = new Mock<ISerializationProvider>();
+
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            var features = new Mock<IFeatureCollection>().SetupAllProperties();
+            var rserviceFeature = new RServiceFeature();
+            context.SetupGet(x => x.Features).Returns(features.Object);
+            features.Setup(x => x[typeof(IRServiceFeature)]).Returns(rserviceFeature);
+            rserviceFeature.ResponseSerializer = expectedProvider.Object;
+
+            var requestSerializationProvider = context.Object.GetResponseSerializationProvider();
+
+            requestSerializationProvider.Should().NotBeNull().And.Be(expectedProvider.Object);
+        }
+
+        [Fact]
+        public void GetResponseSerializationProvider__ReturnsNullIfNotRServiceFeature()
+        {
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            var features = new Mock<IFeatureCollection>().SetupAllProperties();
+            var routingFeature = new Mock<IRoutingFeature>().SetupAllProperties();
+            context.SetupGet(x => x.Features).Returns(features.Object);
+            features.Setup(x => x[typeof(IRoutingFeature)]).Returns(routingFeature.Object);
+
+            var handle = context.Object.GetResponseSerializationProvider();
 
             handle.Should().BeNull();
         }

--- a/test/RService.IO.Tests/ApplicationBuilderExtensionTests.cs
+++ b/test/RService.IO.Tests/ApplicationBuilderExtensionTests.cs
@@ -24,7 +24,7 @@ namespace RService.IO.Tests
         private static readonly Action<RServiceOptions> EmptyRServieOptions = opt => { };
 
         [Fact]
-        public void UserRServiceIo__AddsRoutesToRouting()
+        public void UseRServiceIo__AddsRoutesToRouting()
         {
             IRouteBuilder routeBuilder = null;
             var route = new RouteAttribute("/Foobar");
@@ -49,7 +49,7 @@ namespace RService.IO.Tests
         }
 
         [Fact]
-        public void UserRServiceIo__AddsCustomeRoutesToRouting()
+        public void UseRServiceIo__AddsCustomeRoutesToRouting()
         {
             IRouteBuilder routeBuilder = null;
             const string expectedPath = "Llamas/Eat/Hands";
@@ -73,7 +73,7 @@ namespace RService.IO.Tests
         }
 
         [Fact]
-        public void UserRServiceIo__DefaultsEmptyRouteConfig()
+        public void UseRServiceIo__DefaultsEmptyRouteConfig()
         {
             IRouteBuilder routeBuilder = null;
 
@@ -95,7 +95,7 @@ namespace RService.IO.Tests
         }
 
         [Fact]
-        public void UserRServiceIo__EnablesRouting()
+        public void UseRServiceIo__EnablesRouting()
         {
             var services = new ServiceCollection();
             services.AddRServiceIo(EmptyRServieOptions, EmptyRouteOptions);
@@ -110,7 +110,7 @@ namespace RService.IO.Tests
         }
 
         [Fact]
-        public void UserRServiceIo__EnablesRService()
+        public void UseRServiceIo__EnablesRService()
         {
             var services = new ServiceCollection();
             services.AddRServiceIo(EmptyRServieOptions, EmptyRouteOptions);

--- a/test/RService.IO.Tests/DependencyIngection/ServiceCollectionExtensionTests.cs
+++ b/test/RService.IO.Tests/DependencyIngection/ServiceCollectionExtensionTests.cs
@@ -104,30 +104,31 @@ namespace RService.IO.Tests.DependencyIngection
         }
 
         [Fact]
-        public void AddRServiceIo__AddsNetJsonProviderForISerializationProvider()
+        public void UseRserviceIo__DefaultSerializationProviderIsNetJsonProvider()
         {
             var services = new ServiceCollection();
-
             services.AddRServiceIo(EmptyRServiceOptions);
 
             var app = BuildApplicationBuilder(services);
-            var provider = app.ApplicationServices.GetService<ISerializationProvider>();
+            var options = app.ApplicationServices.GetService<IOptions<RServiceOptions>>();
 
-            provider.Should().NotBeNull().And.BeOfType<NetJsonProvider>();
+            options.Should().NotBeNull();
+            options.Value.Should().NotBeNull();
+            options.Value.DefaultSerializationProvider.Should().BeOfType<NetJsonProvider>();
         }
 
         [Fact]
-        public void AddRServiceIo__UserImplementationForISerializationProviderTakesPrecedence()
+        public void UseRserviceIo__DefaultSerializationProviderAddedToSerializationProviders()
         {
             var services = new ServiceCollection();
-
-            services.AddTransient<ISerializationProvider, SeralizerProvider>();
             services.AddRServiceIo(EmptyRServiceOptions);
 
             var app = BuildApplicationBuilder(services);
-            var provider = app.ApplicationServices.GetService<ISerializationProvider>();
+            var options = app.ApplicationServices.GetService<IOptions<RServiceOptions>>();
 
-            provider.Should().NotBeNull().And.BeOfType<SeralizerProvider>();
+            options.Should().NotBeNull();
+            options.Value.Should().NotBeNull();
+            options.Value.SerializationProviders.Should().ContainKey(new NetJsonProvider().ContentType);
         }
 
         [Fact]
@@ -229,6 +230,7 @@ namespace RService.IO.Tests.DependencyIngection
             return builder.Object;
         }
 
+        // ReSharper disable UnusedMember.Local
         // ReSharper disable ClassNeverInstantiated.Local
         private class ServiceProvider : IServiceProvider
         {
@@ -252,5 +254,6 @@ namespace RService.IO.Tests.DependencyIngection
             }
         }
         // ReSharper restore ClassNeverInstantiated.Local
+        // ReSharper restore UnusedMember.Local
     }
 }

--- a/test/RService.IO.Tests/RServiceMiddlewareTests.cs
+++ b/test/RService.IO.Tests/RServiceMiddlewareTests.cs
@@ -9,9 +9,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using NuGet.Packaging;
 using RService.IO.Abstractions;
+using RService.IO.Abstractions.Providers;
+using RService.IO.Providers;
 using Xunit;
 using Delegate = RService.IO.Abstractions.Delegate;
 using IServiceProvider = RService.IO.Abstractions.Providers.IServiceProvider;
@@ -26,7 +29,10 @@ namespace RService.IO.Tests
 
         public RServiceMiddlewareTests()
         {
-            _options = BuildRServiceOptions(opt => { });
+            _options = BuildRServiceOptions(opt =>
+            {
+                opt.DefaultSerializationProvider = new NetJsonProvider();
+            });
         }
 
         [Fact]
@@ -37,9 +43,7 @@ namespace RService.IO.Tests
             var expectedFeature = new Mock<IRServiceFeature>();
             expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
 
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var routeData = BuildRouteData(routePath);
             var context = BuildContext(routeData);
@@ -61,9 +65,7 @@ namespace RService.IO.Tests
             Delegate.Activator routeActivator = (target, args) => null;
             var serviceMock = new Mock<IService>().SetupAllProperties();
 
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
@@ -84,9 +86,7 @@ namespace RService.IO.Tests
         public async void Invoke__InvokesNextIfRouteHanlderNotSet()
         {
             var hasNextInvoked = false;
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var context = BuildContext(new RouteData());
             var middleware = BuildMiddleware(sink, handler: ctx =>
@@ -105,9 +105,7 @@ namespace RService.IO.Tests
         {
             var hasNextInvoked = false;
             var routePath = "/Foobar".Substring(1);
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var context = BuildContext(new RouteData());
             var middleware = BuildMiddleware(sink, routePath, handler: ctx =>
@@ -125,9 +123,7 @@ namespace RService.IO.Tests
         public async void Invoke__LogsWhenFeatureNotAdded()
         {
             const string expectedMessage = "Request did not match any services.";
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var context = BuildContext(new RouteData());
             var middleware = BuildMiddleware(sink, handler: ctx => Task.FromResult(0));
@@ -147,9 +143,7 @@ namespace RService.IO.Tests
             var expectedFeature = new Mock<IRServiceFeature>();
             expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
 
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
@@ -176,9 +170,7 @@ namespace RService.IO.Tests
             var expectedFeature = new Mock<IRServiceFeature>();
             expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
 
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
@@ -208,9 +200,7 @@ namespace RService.IO.Tests
             var expectedFeature = new Mock<IRServiceFeature>();
             expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
 
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
@@ -240,9 +230,7 @@ namespace RService.IO.Tests
             var expectedFeature = new Mock<IRServiceFeature>();
             expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
 
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
@@ -272,9 +260,7 @@ namespace RService.IO.Tests
             var expectedFeature = new Mock<IRServiceFeature>();
             expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
 
-            var sink = new TestSink(
-               TestSink.EnableWithTypeName<RServiceMiddleware>,
-               TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
@@ -309,9 +295,7 @@ namespace RService.IO.Tests
             var expectedFeature = new Mock<IRServiceFeature>();
             expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
 
-            var sink = new TestSink(
-                TestSink.EnableWithTypeName<RServiceMiddleware>,
-                TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
@@ -341,9 +325,7 @@ namespace RService.IO.Tests
             var expectedFeature = new Mock<IRServiceFeature>();
             expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
 
-            var sink = new TestSink(
-                TestSink.EnableWithTypeName<RServiceMiddleware>,
-                TestSink.EnableWithTypeName<RServiceMiddleware>);
+            var sink = GetTestSink();
 
             var provider = new Mock<IServiceProvider>()
                 .SetupAllProperties();
@@ -363,6 +345,144 @@ namespace RService.IO.Tests
             };
 
             act.ShouldThrow<ApiException>();
+        }
+
+        [Fact]
+        public async void Invoke__AcceptHeaderBlankReturnsNotAcceptable()
+        {
+            var routePath = "/Foobar".Substring(1);
+            Delegate.Activator routeActivator = (target, args) => null;
+            var expectedFeature = new Mock<IRServiceFeature>();
+            expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
+
+            var sink = GetTestSink();
+
+            var provider = new Mock<IServiceProvider>()
+                .SetupAllProperties();
+            provider.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
+                .Returns(Task.FromResult(0));
+
+            var routeData = BuildRouteData(routePath);
+            var context = BuildContext(routeData, ctx => Task.FromResult(0), accept: string.Empty);
+            var middleware = BuildMiddleware(sink, $"{routePath}:GET", routeActivator, serviceProvider: provider.Object);
+
+            await middleware.Invoke(context);
+
+            context.Response.StatusCode.ShouldBeEquivalentTo(HttpStatusCode.NotAcceptable);
+        }
+
+        [Fact]
+        public async void Invoke__AcceptHeaderNotMachingSerialzaitonProviderReturnsNotAcceptable()
+        {
+            var routePath = "/Foobar".Substring(1);
+            Delegate.Activator routeActivator = (target, args) => null;
+            var expectedFeature = new Mock<IRServiceFeature>();
+            expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
+
+            var sink = GetTestSink();
+
+            var provider = new Mock<IServiceProvider>()
+                .SetupAllProperties();
+            provider.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
+                .Returns(Task.FromResult(0));
+
+            var routeData = BuildRouteData(routePath);
+            var context = BuildContext(routeData, ctx => Task.FromResult(0), accept: "text/foobar");
+            var middleware = BuildMiddleware(sink, $"{routePath}:GET", routeActivator, serviceProvider: provider.Object);
+
+            await middleware.Invoke(context);
+
+            context.Response.StatusCode.ShouldBeEquivalentTo(HttpStatusCode.NotAcceptable);
+        }
+
+        [Fact]
+        public async void Invoke__AcceptHeaderAnyUsesDefaultProvider()
+        {
+            var routePath = "/Foobar".Substring(1);
+            const string expectedResponse = "FizzBuzz";
+            Delegate.Activator routeActivator = (target, args) => null;
+            var expectedFeature = new Mock<IRServiceFeature>();
+            expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
+
+            var mockProvider = new Mock<ISerializationProvider>().SetupAllProperties();
+            _options.Value.DefaultSerializationProvider = mockProvider.Object;
+            mockProvider.Setup(x => x.DehydrateResponse(It.IsAny<object>())).Returns(expectedResponse);
+
+            var sink = GetTestSink();
+
+            var provider = new Mock<IServiceProvider>()
+                .SetupAllProperties();
+            var responseMessage = string.Empty;
+            provider.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
+                .Callback<HttpContext>(ctx =>
+                {
+                    var serializer = ctx.GetResponseSerializationProvider();
+                    responseMessage = serializer.DehydrateResponse(null);
+                })
+                .Returns(Task.FromResult(0));
+
+            var routeData = BuildRouteData(routePath);
+            var context = BuildContext(routeData, ctx => Task.FromResult(0), accept: HttpContentTypes.Any);
+            var middleware = BuildMiddleware(sink, $"{routePath}:GET", routeActivator, serviceProvider: provider.Object);
+
+            await middleware.Invoke(context);
+
+            context.Response.StatusCode.ShouldBeEquivalentTo(HttpStatusCode.OK);
+            responseMessage.ShouldAllBeEquivalentTo(expectedResponse);
+        }
+
+        [Fact]
+        public async void Invoke__AcceptHeaderSecondaryUsesSecondaryProvider()
+        {
+            var routePath = "/Foobar".Substring(1);
+            const string expectedResponse = "FizzBuzz";
+            const string mimeType = "application/foobar";
+            Delegate.Activator routeActivator = (target, args) => null;
+            var expectedFeature = new Mock<IRServiceFeature>();
+            expectedFeature.SetupGet(x => x.MethodActivator).Returns(routeActivator);
+
+            var mockProvider = new Mock<ISerializationProvider>().SetupAllProperties();
+            _options.Value.DefaultSerializationProvider = mockProvider.Object;
+            mockProvider.Setup(x => x.DehydrateResponse(It.IsAny<object>())).Returns(expectedResponse);
+
+            var sink = GetTestSink();
+
+            var provider = new Mock<IServiceProvider>()
+                .SetupAllProperties();
+            var responseMessage = string.Empty;
+            provider.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
+                .Callback<HttpContext>(ctx =>
+                {
+                    var serializer = ctx.GetResponseSerializationProvider();
+                    responseMessage = serializer.DehydrateResponse(null);
+                })
+                .Returns(Task.FromResult(0));
+
+            var foobarProvider = new Mock<ISerializationProvider>().SetupAllProperties();
+            foobarProvider.SetupGet(x => x.ContentType).Returns(mimeType);
+            foobarProvider.Setup(x => x.DehydrateResponse(It.IsAny<object>())).Returns(expectedResponse);
+
+            var routeData = BuildRouteData(routePath);
+            var context = BuildContext(routeData, ctx => Task.FromResult(0), accept: mimeType);
+            var options = BuildRServiceOptions(opt =>
+            {
+                opt.DefaultSerializationProvider = new NetJsonProvider();
+                opt.SerializationProviders.Add(mimeType, foobarProvider.Object);
+            });
+            var middleware = BuildMiddleware(sink, $"{routePath}:GET", routeActivator,
+                serviceProvider: provider.Object, options: options);
+
+            await middleware.Invoke(context);
+
+            context.Response.StatusCode.ShouldBeEquivalentTo(HttpStatusCode.OK);
+            responseMessage.ShouldAllBeEquivalentTo(expectedResponse);
+        }
+
+        private static TestSink GetTestSink()
+        {
+            return new TestSink(
+                TestSink.EnableWithTypeName<RServiceMiddleware>,
+                TestSink.EnableWithTypeName<RServiceMiddleware>);
         }
 
         private static RouteData BuildRouteData(string path)
@@ -385,7 +505,7 @@ namespace RService.IO.Tests
         }
 
         private static HttpContext BuildContext(RouteData routeData, RequestDelegate handler = null, string method = "GET",
-            IExceptionFilter globalExceptionFilter = null, IService service = null)
+            IExceptionFilter globalExceptionFilter = null, IService service = null, string accept = null)
         {
             var context = new DefaultHttpContext();
             var ioc = new Mock<System.IServiceProvider>().SetupAllProperties();
@@ -406,6 +526,7 @@ namespace RService.IO.Tests
 
             context.RequestServices = ioc.Object;
             context.Request.Method = method;
+            context.Request.Headers.Add("Accept", new StringValues(accept ?? "*/*"));
             context.Response.Body = new MemoryStream();
 
             return context;

--- a/test/RService.IO.Tests/RServiceOptionsTests.cs
+++ b/test/RService.IO.Tests/RServiceOptionsTests.cs
@@ -7,41 +7,39 @@ namespace RService.IO.Tests
 {
     public class RServiceOptionsTests
     {
+        private readonly RServiceOptions _options = new RServiceOptions();
+
         [Fact]
         public void AddServiceAsssembly__AddsAssemblyFromType()
         {
             var type = typeof(SvcWithMethodRoute);
             var asm = type.GetTypeInfo().Assembly;
-            var options = new RServiceOptions();
-            
-            options.AddServiceAssembly(type);
 
-            options.ServiceAssemblies.Should().Contain(asm);
+            _options.AddServiceAssembly(type);
+
+            _options.ServiceAssemblies.Should().Contain(asm);
         }
 
         [Fact]
         public void ServiceAssemblies__DefaultsToEmptyList()
         {
-            var options = new RServiceOptions();
 
-            options.ServiceAssemblies.Should().NotBeNull();
-            options.ServiceAssemblies.Count.Should().Be(0);
+            _options.ServiceAssemblies.Should().NotBeNull();
+            _options.ServiceAssemblies.Count.Should().Be(0);
         }
 
         [Fact]
         public void AddServiceAssembly__ThrowsExceptionOnNullType()
         {
-            var options = new RServiceOptions();
-            Action comparison = () => options.AddServiceAssembly(null);
+            Action comparison = () => _options.AddServiceAssembly(null);
             comparison.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
         public void EnableDebugging__DefaultsToFalse()
         {
-            var options = new RServiceOptions();
+            _options.EnableDebugging.Should().BeFalse();
 
-            options.EnableDebugging.Should().BeFalse();
         }
     }
 }

--- a/test/RService.IO.Tests/RServiceOptionsTests.cs
+++ b/test/RService.IO.Tests/RServiceOptionsTests.cs
@@ -39,7 +39,19 @@ namespace RService.IO.Tests
         public void EnableDebugging__DefaultsToFalse()
         {
             _options.EnableDebugging.Should().BeFalse();
+        }
 
+        [Fact]
+        public void SerializationProviders__DefaultsToEmptyDictionary()
+        {
+            _options.SerializationProviders.Should().NotBeNull()
+                .And.Subject.Count.ShouldBeEquivalentTo(0);
+        }
+
+        [Fact]
+        public void DefaultSerializationProvider__DefaultsToNull()
+        {
+            _options.DefaultSerializationProvider.Should().BeNull();
         }
     }
 }

--- a/test/Rservice.IO.Tests.Integration/MiddlewareTests.cs
+++ b/test/Rservice.IO.Tests.Integration/MiddlewareTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using RService.IO;
 using RService.IO.Abstractions.Providers;
@@ -43,6 +45,10 @@ namespace Rservice.IO.Tests.Integration
             _rserviceAuthServer = new TestServer(new WebHostBuilder()
                 .UseStartup<RServiceAuthStartup>());
             _rserviceAuthClient = _rserviceAuthServer.CreateClient();
+
+            _routeClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            _rserviceClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            _rserviceAuthClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
         }
 
         [Theory]


### PR DESCRIPTION
Allows for `Content-Type` and `Accept` headers to determine the serializer to use for **request** and **response** bodies.