### PR TITLE
Release v0.4.3

### DIFF
--- a/src/RService.IO.Abstractions/project.json
+++ b/src/RService.IO.Abstractions/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "RService.IO.Abstractions",
-  "version": "0.4.2",
+  "version": "0.4.3",
 
   "packOptions": {
     "summary": "The abstractions required for implementing a RService.IO service and routes.",

--- a/src/RService.IO.Authorization/project.json
+++ b/src/RService.IO.Authorization/project.json
@@ -1,6 +1,6 @@
 ﻿{
     "title": "RService.IO.Authorization",
-    "version": "0.4.2",
+    "version": "0.4.3",
 
     "packOptions": {
         "summary": "RService.IO authorization provider.",

--- a/src/RService.IO/RServiceMiddleware.cs
+++ b/src/RService.IO/RServiceMiddleware.cs
@@ -64,8 +64,8 @@ namespace RService.IO
                         acceptHeader = new StringValues(HttpContentTypes.Any);
 
                     if (acceptHeader.TakeWhile(header => !_options.SerializationProviders
-                            .TryGetValue(header, out responseSerializer))
-                            .Any(header => header == HttpContentTypes.Any))
+                            .TryGetValue(header.Split(';')[0], out responseSerializer))
+                            .Any(header => header.StartsWith( HttpContentTypes.Any)))
                         responseSerializer = _options.DefaultSerializationProvider;
 
                     if (responseSerializer == null)

--- a/src/RService.IO/project.json
+++ b/src/RService.IO/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "RService.IO",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "packOptions": {
     "summary": "A web service framework for dotnet core loosely based on ServiceStack v3",
     "releaseNotes": "Initial alpha release",


### PR DESCRIPTION
* Custom serialization providers to support additional MIME types.
* Default `ACCEPT` header to `*/*` if not supplied.
* `ACCEPT` header quality attribute is partially supported (still matches MIME type, but does not prioritize)